### PR TITLE
Integration with Rhino CLI

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -17,6 +17,7 @@
     <property name="node.build.file" value="csslint-node.js"/>
     <property name="worker.build.file" value="csslint-worker.js"/>
     <property name="tests.build.file" value="csslint-tests.js"/>
+    <property name="rhino.build.file" value="csslint-rhino.js"/>
     
     <loadfile property="license.text" srcfile="LICENSE" />   
 
@@ -92,10 +93,19 @@
             <fileset dir="${tests.dir}/rules" includes="*.js" />           
         </concat>        
     </target>   
+
+
+    <!-- build for rhino CLI integration -->
+    <target name="build.rhino" depends="build.core">
+        <concat destfile="${build.dir}/${rhino.build.file}" fixlastline="true">
+            <filelist dir="${build.dir}" files="${core.build.file}" />
+            <filelist dir="${src.dir}/rhino" files="rhino.js" />
+        </concat>
+    </target>
     
     
     
     <!-- Build all files -->
-    <target name="all" depends="clean,build.core,build.worker,build.node,build.tests"/>
+    <target name="all" depends="clean,build.core,build.worker,build.node,build.tests,build.rhino"/>
 
 </project>

--- a/src/rhino/rhino.js
+++ b/src/rhino/rhino.js
@@ -1,0 +1,23 @@
+(function(a) {
+    var input, results;
+    if (!a[0]) {
+        print("Usage: csslint-rhino.js file.css"); 
+        quit(1);
+    }
+    input = readFile(a[0]);
+    if (!input) {
+        print("CSSLint could not open file: '" + a[0] + "'."); 
+        quit(1);
+    }
+    results = CSSLint.verify(input);
+    if (results && results.messages && results.messages.length > 0) {
+        for (i = 0, len = results.messages.length; i < len; ++i) {
+            cur = results.messages[i];
+            print(cur["type"] + " at line " + cur["line"] + " character " + cur["col"] + ": " + cur["rule"]["desc"]);
+            print(cur["evidence"] + "\n");
+        }
+    }
+    else {
+        print("csslint: No problems found in " + a[0]);
+    }
+})(arguments);


### PR DESCRIPTION
I implemented a simple turnkey to allow the Rhino js.jar to execute the CSSLint.verify() method on a file argument.  This is almost identical to how JSLint integrates with Rhino.

Please let me know if you have any feedback on how I did this.  This is my first github pull request.
