### PR TITLE
Add CSSLint XML formatter

### DIFF
--- a/src/formatters/csslint-xml.js
+++ b/src/formatters/csslint-xml.js
@@ -1,0 +1,53 @@
+CSSLint.addFormatter({
+    //format information
+    id: "csslint-xml",
+    name: "CSSLint XML format",
+    
+    /**
+     * Return opening root XML tag.
+     * @return {String} to prepend before all results
+     */
+    startFormat: function(){
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?><csslint>";
+    },
+
+    /**
+     * Return closing root XML tag.
+     * @return {String} to append after all results
+     */
+    endFormat: function(){
+        return "</csslint>";
+    },
+    
+    formatResults: function(results, filename) {
+        var messages = results.messages,
+            output = [];
+
+        /**
+         * Replace double-quotes with single quotes for XML output
+         * @param {String} message to escape
+         * @return escaped message as {String}
+         */
+        var replaceDoubleQuotes = function(str) {
+            if (!str || str.constructor !== String) {
+                return "";
+            }
+            return str.replace(/\"/g, "'");
+        };
+
+        if (messages.length > 0) {
+            output.push("<file name=\""+filename+"\">");
+            messages.forEach(function (message, i) {
+                if (message.rollup) {
+                    output.push("<issue severity=\"" + message.type + "\" reason=\"" + replaceDoubleQuotes(message.message) + "\" evidence=\"" + replaceDoubleQuotes(message.evidence) + "\"/>");
+                } else {
+                    output.push("<issue line=\"" + message.line + "\" char=\"" + message.col + "\" severity=\"" + message.type + "\"" +
+                        " reason=\"" + replaceDoubleQuotes(message.message) + "\" evidence=\"" + replaceDoubleQuotes(message.evidence) + "\"/>");
+                }
+            });
+            output.push("</file>");
+        }
+
+        return output.join("");
+    }
+});

--- a/tests/formatters/csslint-xml.js
+++ b/tests/formatters/csslint-xml.js
@@ -1,0 +1,42 @@
+(function(){
+
+    /*global YUITest, CSSLint*/
+    var Assert = YUITest.Assert;
+
+    YUITest.TestRunner.add(new YUITest.TestCase({
+        name: "CSSLint XML formatter test",
+        
+        "File with no problems should say so": function(){
+            var result = { messages: [], stats: [] },
+                expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?><csslint></csslint>";
+            Assert.areEqual(expected, CSSLint.format(result, "FILE", "csslint-xml"));
+        },
+
+        "File with problems should list them": function(){
+            var result = { messages: [
+                     { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] },
+                     { type: "error", line: 2, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] }
+                ], stats: [] },
+                file = "<file name=\"FILE\">",
+                error1 = "<issue line=\"1\" char=\"1\" severity=\"warning\" reason=\"BOGUS\" evidence=\"ALSO BOGUS\"/>",
+                error2 = "<issue line=\"2\" char=\"1\" severity=\"error\" reason=\"BOGUS\" evidence=\"ALSO BOGUS\"/>",
+                expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?><csslint>" + file + error1 + error2 + "</file></csslint>",
+                actual = CSSLint.format(result, "FILE", "csslint-xml");
+            Assert.areEqual(expected, actual);
+        },
+
+        "Formatter should escape double quotes": function() {
+            var doubleQuotedEvidence = 'sneaky, "sneaky"',
+                result = { messages: [
+                     { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: doubleQuotedEvidence, rule: [] },
+                     { type: "error", line: 2, col: 1, message: "BOGUS", evidence: doubleQuotedEvidence, rule: [] }
+                ], stats: [] },
+                file = "<file name=\"FILE\">",
+                error1 = "<issue line=\"1\" char=\"1\" severity=\"warning\" reason=\"BOGUS\" evidence=\"sneaky, 'sneaky'\"/>",
+                error2 = "<issue line=\"2\" char=\"1\" severity=\"error\" reason=\"BOGUS\" evidence=\"sneaky, 'sneaky'\"/>",
+                expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?><csslint>" + file + error1 + error2 + "</file></csslint>",
+                actual = CSSLint.format(result, "FILE", "csslint-xml");
+            Assert.areEqual(expected, actual);
+        }
+    }));
+})();


### PR DESCRIPTION
Adding csslint-xml format as discussed in Google group for integration with the Jenkins Violations plugin; without the changes to the compact formatter this time. 
