### PR TITLE
Change path.join to path.resolve so that '..', '/', '~' can be used as the filename successfully, fixes #166

### DIFF
--- a/src/cli/common-cli.js
+++ b/src/cli/common-cli.js
@@ -36,7 +36,7 @@ if (options.version){
 
 //get the full path names
 files = files.map(function(filename){
-    return path.join(CLI.getCurrentDirectory(), filename);
+    return path.resolve(CLI.getCurrentDirectory(), filename);
 });
 
 CLI.quit(CLI.processFiles(files,options));

--- a/src/cli/node-cli.js
+++ b/src/cli/node-cli.js
@@ -106,7 +106,7 @@ if (options.version){
 
 //get the full path names
 files = files.map(function(filename){
-    return path.join(process.cwd(), filename);
+    return path.resolve(process.cwd(), filename);
 });
 
 process.exit(processFiles(files,options));

--- a/src/cli/node.js
+++ b/src/cli/node.js
@@ -86,7 +86,7 @@ if (options.version){
 
 //get the full path names
 files = files.map(function(filename){
-    return path.join(process.cwd(), filename);
+    return path.resolve(process.cwd(), filename);
 });
 
 process.exit(processFiles(files,options));


### PR DESCRIPTION
Here's a copy of the description of issue #166

in cli.js:

```
files = files.map(function(filename){
    return path.join(process.cwd(), filename);
});
```

This will prepend the cwd to the filename even when the filename is actually a full path. using path.resolve should fix this:
(http://nodejs.org/docs/v0.5.4/api/path.html#path.resolve)

```
files = files.map(function(filename){
    return path.resolve(process.cwd(), filename);
});
```

In the node shell:

```
>path.join("/a/b/c", "/d/e")
'/a/b/c/d/e'
>path.resolve("/a/b/c", "/d/e")
'/d/e'
```
