### PR TITLE
Escape special chars in Checkstyle XML output

### DIFF
--- a/src/formatters/checkstyle-xml.js
+++ b/src/formatters/checkstyle-xml.js
@@ -29,6 +29,24 @@ CSSLint.addFormatter({
             return 'net.csslint.' + rule.name.replace(/\s/g,'');
         };
 
+        /**
+         * Replace special characters before write to output.
+         *
+         * Rules:
+         *  - single quotes is the escape sequence for double-quotes
+         *  - &lt; is the escape sequence for <
+         *  - &gt; is the escape sequence for >
+         *
+         * @param {String} message to escape
+         * @return escaped message as {String}
+         */
+        var escapeSpecialCharacters = function(str) {
+            if (!str || str.constructor !== String) {
+                return "";
+            }
+            return str.replace(/\"/g, "'").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        };
+
         if (messages.length > 0) {
             output.push("<file name=\""+filename+"\">");
             messages.forEach(function (message, i) {
@@ -36,7 +54,7 @@ CSSLint.addFormatter({
                     //ignore rollups for now
                 } else {
                   output.push("<error line=\"" + message.line + "\" column=\"" + message.col + "\" severity=\"" + message.type + "\"" +
-                      " message=\"" + message.message + "\" source=\"" + generateSource(message.rule) +"\"/>");
+                      " message=\"" + escapeSpecialCharacters(message.message) + "\" source=\"" + generateSource(message.rule) +"\"/>");
                 }
             });
             output.push("</file>");

--- a/tests/formatters/checkstyle-xml.js
+++ b/tests/formatters/checkstyle-xml.js
@@ -25,5 +25,20 @@
                 actual = CSSLint.format(result, "FILE", "checkstyle-xml");
             Assert.areEqual(expected, actual);
         },
+
+        "Formatter should escape special characters": function() {
+            var specialCharsSting = 'sneaky, "sneaky", <sneaky>',
+                result = { messages: [
+                     { type: "warning", line: 1, col: 1, message: specialCharsSting, evidence: "ALSO BOGUS", rule: [] },
+                     { type: "error", line: 2, col: 1, message: specialCharsSting, evidence: "ALSO BOGUS", rule: [] }
+                ], stats: [] },
+                file = "<file name=\"FILE\">",
+                error1 = "<error line=\"1\" column=\"1\" severity=\"warning\" message=\"sneaky, 'sneaky', &lt;sneaky&gt;\" source=\"\"/>",
+                error2 = "<error line=\"2\" column=\"1\" severity=\"error\" message=\"sneaky, 'sneaky', &lt;sneaky&gt;\" source=\"\"/>",
+                expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle>" + file + error1 + error2 + "</file></checkstyle>",
+                actual = CSSLint.format(result, "FILE", "checkstyle-xml");
+            Assert.areEqual(expected, actual);
+        }
+
     }));
 })();


### PR DESCRIPTION
The Checkstyle formatter should escape special characters when printing the error message.

Also added a bit of defensive coding for source generation if a proper rule is not passed.
