### PR TITLE
Added --quiet flag

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -68,7 +68,7 @@ function cli(api){
             api.print("csslint: Could not read file data in " + filename + ". Is the file empty?");
             exitCode = 1;
         } else {
-            api.print(CSSLint.getFormatter(formatId).formatResults(result, filename, formatId));
+            api.print(CSSLint.getFormatter(formatId).formatResults(result, filename, options));
 
             if (messages.length > 0 && pluckByType(messages, "error").length > 0) {
                 exitCode = 1;

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -57,7 +57,7 @@ var processFile = function(filename, options) {
         print("csslint: Could not read file data in " + filename + ". Is the file empty?");
         exitCode = 1;
     } else {
-        print(CSSLint.getFormatter(formatId).formatResults(result, filename, formatId));
+        print(CSSLint.getFormatter(formatId).formatResults(result, filename, options));
 
         if (messages.length > 0 && pluckByType(messages, 'error').length > 0) {
             exitCode = 1;

--- a/src/core/CSSLint.js
+++ b/src/core/CSSLint.js
@@ -74,16 +74,17 @@ var CSSLint = (function(){
      * @param {Object} result The results returned from CSSLint.verify().
      * @param {String} filename The filename for which the results apply.
      * @param {String} formatId The name of the formatter to use.
+     * @param {Object} options for formatting
      * @return {String} A formatted string for the results.
      * @method format
      */
-    api.format = function(results, filename, formatId) {
+    api.format = function(results, filename, formatId, options) {
         var formatter = this.getFormatter(formatId),
             result = null;
             
         if (formatter){
             result = formatter.startFormat();
-            result += formatter.formatResults(results, filename);
+            result += formatter.formatResults(results, filename, options || {});
             result += formatter.endFormat();
         }
         

--- a/src/formatters/checkstyle-xml.js
+++ b/src/formatters/checkstyle-xml.js
@@ -11,7 +11,7 @@ CSSLint.addFormatter({
         return "</checkstyle>";
     },
 
-    formatResults: function(results, filename) {
+    formatResults: function(results, filename, options) {
         var messages = results.messages,
             output = [];
 

--- a/src/formatters/compact.js
+++ b/src/formatters/compact.js
@@ -11,14 +11,14 @@ CSSLint.addFormatter({
         return "";
     },
 
-    formatResults: function(results, filename) {
+    formatResults: function(results, filename, options) {
         var messages = results.messages,
             output = "",
             pos = filename.lastIndexOf("/"),
             shortFilename = filename;
 
         if (messages.length === 0) {
-            return shortFilename + ": Lint Free!";
+            return options.quiet ? "" : shortFilename + ": Lint Free!";
         }
 
         if (pos == -1){

--- a/src/formatters/csslint-xml.js
+++ b/src/formatters/csslint-xml.js
@@ -19,7 +19,7 @@ CSSLint.addFormatter({
         return "</csslint>";
     },
     
-    formatResults: function(results, filename) {
+    formatResults: function(results, filename, options) {
         var messages = results.messages,
             output = [];
 

--- a/src/formatters/lint-xml.js
+++ b/src/formatters/lint-xml.js
@@ -11,7 +11,7 @@ CSSLint.addFormatter({
         return "</lint>";
     },
     
-    formatResults: function(results, filename) {
+    formatResults: function(results, filename, options) {
         var messages = results.messages,
             output = [];
 

--- a/src/formatters/text.js
+++ b/src/formatters/text.js
@@ -11,10 +11,10 @@ CSSLint.addFormatter({
         return "";
     },
 
-    formatResults: function(results, filename) {
+    formatResults: function(results, filename, options) {
         var messages = results.messages;
         if (messages.length === 0) {
-            return "\n\ncsslint: No errors in " + filename + ".";
+            return options.quiet ? "" : "\n\ncsslint: No errors in " + filename + ".";
         }
         
         output = "\n\ncsslint: There are " + messages.length  +  " problems in " + filename + ".";

--- a/tests/formatters/compact.js
+++ b/tests/formatters/compact.js
@@ -11,6 +11,11 @@
             Assert.areEqual("FILE: Lint Free!", CSSLint.format(result, "FILE", "compact"));
         },
 
+        "File with no problems should not say so if quiet": function(){
+            var result = { messages: [], stats: [] };
+            Assert.areEqual("", CSSLint.format(result, "FILE", "compact", {quiet: true}));
+        },
+
         "File with problems should list them": function(){
             var result = { messages: [ 
                      { type: 'warning', line: 1, col: 1, message: 'BOGUS WARNING', evidence: 'BOGUS', rule: [] },

--- a/tests/formatters/text.js
+++ b/tests/formatters/text.js
@@ -12,6 +12,11 @@
             Assert.areEqual("\n\ncsslint: No errors in FILE.", CSSLint.format(result, "FILE", "text"));
         },
 
+        "File with no problems shouldn't say so if quiet": function (){
+            var result = { messages: [], stats: [] };
+            Assert.areEqual("", CSSLint.format(result, "FILE", "text", {quiet: true}));
+        },
+
         "File with problems should list them": function(){
             var result = { messages: [ 
                      { type: 'warning', line: 1, col: 1, message: 'BOGUS', evidence: 'ALSO BOGUS', rule: [] },


### PR DESCRIPTION
added --quiet flag to suppress 'no errors' msg on text and compact formatters for issue #170

Ideally csslint should support custom formatters that can be plugged in (going to take a stab at this at some point in the near future) but until then this seemed like a nice enough refactor.  

None of the formatters currently used the formatterID param anyways so I switched it for the options object to allow passing of custom options (like quiet) to the formatters.
