### PR TITLE
Minor formatting tweak to `--list-rules` 

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -56,7 +56,7 @@ function cli(api){
         api.print("");
         var rules = CSSLint.getRules();
         rules.forEach(function(rule){
-            api.print(rule.id + "\n" + rule.desc + "\n");
+            api.print(rule.id + "\n  " + rule.desc + "\n");
         });
     }
 


### PR DESCRIPTION
Added a modest 2-space indent to the rule’s descriptions for readability.
