### PR TITLE
'Evidence' is wrong when running under WSH

### DIFF
--- a/src/core/CSSLint.js
+++ b/src/core/CSSLint.js
@@ -125,7 +125,7 @@ var CSSLint = (function(){
             parser = new parserlib.css.Parser({ starHack: true, ieFilters: true,
                                                 underscoreHack: true, strict: false });
 
-        lines = text.split(/\n\r?/g);
+        lines = text.replace(/\n\r?/g, "$split$").split('$split$');
         
         if (!ruleset){
             ruleset = {};


### PR DESCRIPTION
This is seems to be a bug with the regex use of split, blank lines are not included so the line number used for evidence don't match up.

Using a regex to do the split skips all blank lines:

``` javascript
lines = text.split(/\n\r?/g); //current code
```

This can be fixed if you instead use the regex to replace line feeds with a unique value and then a simple string to split on (not a regex).

``` javascript
lines = text.replace(/\n\r?/g, "$split$").split('$split$'); //fix that worked for me :)
```
