### PR TITLE
Adding win32 as an allowed OS

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -3,7 +3,7 @@
     "version": "@VERSION@",
     "description": "CSSLint",
     "author": "Nicholas C. Zakas",
-    "os": ["darwin", "linux"],
+    "os": ["darwin", "linux", "win32"],
     "contributors": [
         "Nicole Sullivan"
     ],


### PR DESCRIPTION
I want to use this on windows under node and from testing it like this:

```
node ..\github\csslint\release\npm\cli.js .\style.css
```

It works just fine. I don't see why this can't be added as an allowed OS to the package.json file
