### PR TITLE
The regular rule test should be as bland as possible

### DIFF
--- a/tests/all-rules.js
+++ b/tests/all-rules.js
@@ -49,7 +49,7 @@
                 },
 
                 "Using a regular rule should not result in an error": function(){
-                    var result = CSSLint.verify("div { width: 100px; }", this.options);
+                    var result = CSSLint.verify("body { margin: 0; }", this.options);
                     Assert.areEqual(0, result.messages.length);
                 }
 


### PR DESCRIPTION
I got a custom rule which checks if you're adhering to some naming conventions. A ruleset like: `.foo { width: 100px; }` (which is currently used by _tests/all-rules.js_) does trigger a warning.

I replaced it with that kind of rule everyone is using: `body { margin: 0; }`.

That was the most neutral thing I could think of.
