### PR TITLE
added one-selector-per-line rule, fixes #280

### DIFF
--- a/src/rules/one-selector-per-line.js
+++ b/src/rules/one-selector-per-line.js
@@ -1,0 +1,32 @@
+/*
+ * Rule: Put each selector in its own line.
+ */
+
+/*jslint plusplus:false*/
+/*global CSSLint*/
+
+CSSLint.addRule({
+
+    //rule information
+    id: "one-selector-per-line",
+    name: "At most one selector per line",
+    desc: "To increase readability, put each selector in its own line.",
+    browsers: "All",
+
+    //initialization
+    init: function (parser, reporter) {
+        var rule = this;
+
+        parser.addListener("startrule", function (event) {
+            var i, len, selectors, previousLine, currentLine;
+            selectors = event.selectors;
+            for (i = 0, len = selectors.length; i < len; i++) {
+                currentLine = selectors[i].parts[0].line;
+                if (currentLine === previousLine) {
+                    reporter.report("multiple selectors in one line found", currentLine, selectors[i].parts[0].col, rule);
+                }
+                previousLine = currentLine;
+            }
+        });
+    }
+});

--- a/tests/rules/one-selector-per-line.js
+++ b/tests/rules/one-selector-per-line.js
@@ -1,0 +1,35 @@
+/*global YUITest, CSSLint*/
+(function () {
+
+    var ruleId = "one-selector-per-line", expectWarning, expectPass;
+
+    expectWarning = function (ruleset, expectedMessage) {
+        var result, enabledRules = {};
+        enabledRules[ruleId] = 1;
+        result = CSSLint.verify(ruleset, enabledRules);
+        YUITest.Assert.areEqual(1, result.messages.length);
+        YUITest.Assert.areEqual("warning", result.messages[0].type);
+        YUITest.Assert.areEqual(expectedMessage, result.messages[0].message);
+    };
+
+    expectPass = function (ruleset) {
+        var result, enabledRules = {};
+        enabledRules[ruleId] = 1;
+        result = CSSLint.verify(ruleset, enabledRules);
+        YUITest.Assert.areEqual(0, result.messages.length);
+    };
+
+    YUITest.TestRunner.add(new YUITest.TestCase({
+
+        name: ruleId + " Rule Errors",
+
+        "two selectors in one line should result in a warning": function () {
+            expectWarning(".foo, .bar{}", "multiple selectors in one line found");
+        },
+        "two selectors in two separate should not result in a warning": function () {
+            expectPass(".foo,\n.bar{}");
+        }
+
+    }));
+
+}());


### PR DESCRIPTION
The rule complains if there is more than one selector per line.
