### PR TITLE
New rule which looks for new-line characters in selectors

### DIFF
--- a/src/rules/no-new-lines-in-selectors.js
+++ b/src/rules/no-new-lines-in-selectors.js
@@ -1,0 +1,37 @@
+/*
+ * Rule: Avoid new-line characters in selectors.
+ */
+
+/*jslint plusplus:false*/
+/*global CSSLint*/
+
+CSSLint.addRule({
+
+    //rule information
+    id: "no-new-lines-in-selectors",
+    name: "Disallow new-line characters in selectors",
+    desc: "New-line characters in selectors are usually a forgotten comma and not a descendant combinator.",
+    browsers: "All",
+
+    //initialization
+    init: function (parser, reporter) {
+        var rule = this;
+
+        parser.addListener("startrule", function (event) {
+            var i, len, selectors, selector, p, pLen, part, previousLine, currentLine;
+            selectors = event.selectors;
+
+            for (i = 0, len = selectors.length; i < len; i++) {
+                selector = selectors[i];
+                for (p = 0, pLen = selector.parts.length; p < pLen; p++) {
+                    part = selector.parts[p];
+                    currentLine = part.line;
+                    if (currentLine === previousLine) {
+                        reporter.report("new-line character found in selector (forgot a comma?)", currentLine, selectors[i].parts[0].col, rule);
+                    }
+                    previousLine = currentLine;
+                }
+            }
+        });
+    }
+});

--- a/tests/rules/no-new-lines-in-selectors.js
+++ b/tests/rules/no-new-lines-in-selectors.js
@@ -1,0 +1,34 @@
+/*global YUITest, CSSLint*/
+(function () {
+
+    var ruleId = "no-new-lines-in-selectors", expectWarning, expectPass;
+
+    expectWarning = function (ruleset, expectedMessage) {
+        var result, enabledRules = {};
+        enabledRules[ruleId] = 1;
+        result = CSSLint.verify(ruleset, enabledRules);
+        YUITest.Assert.areEqual(1, result.messages.length);
+        YUITest.Assert.areEqual("warning", result.messages[0].type);
+        YUITest.Assert.areEqual(expectedMessage, result.messages[0].message);
+    };
+
+    expectPass = function (ruleset) {
+        var result, enabledRules = {};
+        enabledRules[ruleId] = 1;
+        result = CSSLint.verify(ruleset, enabledRules);
+        YUITest.Assert.areEqual(0, result.messages.length);
+    };
+
+    YUITest.TestRunner.add(new YUITest.TestCase({
+
+        name: ruleId + " Rule Errors",
+
+        "a new-line in a selector should result in a warning": function () {
+            expectWarning(".foo\n.bar{}", "new-line character found in selector (forgot a comma?)");
+        },
+        "a new-line between selectors should not result in a warning": function () {
+            expectPass(".foo,\n.bar{}");
+        }
+    }));
+
+}());


### PR DESCRIPTION
New-line characters are usually a forgotten comma, not a descendant combinator.

While the spec defines the descendant combinator as any kind of whitespace [1], no one seems to use new-line characters deliberately for this. After all, it looks like an editing mistake and usually it is indeed an editing mistake. Furthermore, most people do not know that "E F" and "E\nF" are actually the same. So, they won't even consider that this might have been done on purpose.

Not okay:

```
.foo
.bar {
    color: #ccc;
}
```

**Yields:** "new-line character found in selector (forgot a comma?)"

Most likely it was supposed to look like this:

```
.foo,
.bar {
    color: #ccc;
}
```

If that was indeed supposed to be a descendant combinator, it should have been written like this:

```
.foo .bar {
    color: #ccc;
}
```

---

[1] http://www.w3.org/TR/css3-selectors/#descendant-combinators

> A descendant combinator is whitespace that separates two sequences of simple selectors.
