### PR TITLE
Basic Contributor guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+# Contributor guidelines - CSSLint* Check out the [Contributing wiki](https://github.com/stubbornella/csslint/wiki/Contributing) and [Developer Guidelines](https://github.com/stubbornella/csslint/wiki/Developer-Guide) first* To add properties that CSSLint recognizes, submit a patch to [https://github.com/nzakas/parser-lib](nzakas/parser-lib)


### PR DESCRIPTION
Points to the wiki, but used for GitHub integration https://github.com/blog/1184-contributing-guidelines
