### PR TITLE
disable IE5/IE6 Doubled Float Margin Warning

### DIFF
--- a/src/rules/display-property-grouping.js
+++ b/src/rules/display-property-grouping.js
@@ -62,9 +62,9 @@ CSSLint.addRule({
                         reportProperty("margin", display);
                         reportProperty("margin-top", display);
                         reportProperty("margin-bottom", display);
-						if(properties.display.hack === null){
-							reportProperty("float", display, "display:inline has no effect on floated elements.");
-						}
+                        if(properties.display.hack === null){
+                            reportProperty("float", display, "display:inline has no effect on floated elements.");
+                        }
                         break;
 
                     case "block":

--- a/src/rules/display-property-grouping.js
+++ b/src/rules/display-property-grouping.js
@@ -61,8 +61,10 @@ CSSLint.addRule({
                         reportProperty("width", display);
                         reportProperty("margin", display);
                         reportProperty("margin-top", display);
-                        reportProperty("margin-bottom", display);              
-                        reportProperty("float", display, "display:inline has no effect on floated elements (but may be used to fix the IE6 double-margin bug).");
+                        reportProperty("margin-bottom", display);
+						if(properties.display.hack === null){
+							reportProperty("float", display, "display:inline has no effect on floated elements.");
+						}
                         break;
 
                     case "block":
@@ -99,10 +101,11 @@ CSSLint.addRule({
         parser.addListener("startpage", startRule);
 
         parser.addListener("property", function(event){
-            var name = event.property.text.toLowerCase();
+            var property = event.property,
+				name = event.property.text.toLowerCase();
 
             if (propertiesToCheck[name]){
-                properties[name] = { value: event.value.text, line: event.property.line, col: event.property.col };                    
+                properties[name] = { value: event.value.text, line: property.line, col: property.col, hack: property.hack };                    
             }
         });
 

--- a/tests/rules/display-property-grouping.js
+++ b/tests/rules/display-property-grouping.js
@@ -24,7 +24,12 @@
             var result = CSSLint.verify(".foo { float: left; display: inline; }", { "display-property-grouping": 1 });
             Assert.areEqual(1, result.messages.length);
             Assert.areEqual("warning", result.messages[0].type);
-            Assert.areEqual("display:inline has no effect on floated elements (but may be used to fix the IE6 double-margin bug).", result.messages[0].message);
+            Assert.areEqual("display:inline has no effect on floated elements.", result.messages[0].message);
+        },
+		
+        "Float with hacked inline should not result in a warning": function(){
+            var result = CSSLint.verify(".foo { float: left; _display: inline; }", { "display-property-grouping": 1 });
+            Assert.areEqual(0, result.messages.length);
         },
 
         "Float:none with inline-block should not result in a warning": function(){


### PR DESCRIPTION
disable warning when use hack display for fix IE5/IE6 Doubled Float Margin:

	display:block;
	_display:inline;
	float:left;