### PR TITLE
Adding a new rule (bulletproof @font-face declarations)

### DIFF
--- a/src/rules/bulletproof-font-face.js
+++ b/src/rules/bulletproof-font-face.js
@@ -1,0 +1,66 @@
+/*
+ * Rule: Use the bulletproof @font-face syntax to avoid 404's in old IE
+ * (http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax)
+ */
+/*global CSSLint*/
+CSSLint.addRule({
+
+    //rule information
+    id: "bulletproof-font-face",
+    name: "Use the bulletproof @font-face syntax",
+    desc: "Use the bulletproof @font-face syntax to avoid 404's in old IE (http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax).",
+    browsers: "All",
+
+    //initialization
+    init: function(parser, reporter){
+        var rule = this,
+            count = 0,
+            fontFaceRule = false,
+            firstSrc     = true,
+            ruleFailed    = false,
+            line, col;
+
+        // Mark the start of a @font-face declaration so we only test properties inside it
+        parser.addListener("startfontface", function(event){
+            fontFaceRule = true;
+        });
+
+        parser.addListener("property", function(event){
+            // If we aren't inside an @font-face declaration then just return
+            if (!fontFaceRule) {
+                return;
+            }
+
+            var propertyName = event.property.toString().toLowerCase(),
+                value        = event.value.toString();
+
+            // Set the line and col numbers for use in the endfontface listener
+            line = event.line;
+            col  = event.col;
+
+            // This is the property that we care about, we can ignore the rest
+            if (propertyName === 'src') {
+                var regex = /^\s?url\(['"].+\.eot\?.*['"]\)\s*format\(['"]embedded-opentype['"]\).*$/i;
+
+                // We need to handle the advanced syntax with two src properties
+                if (!value.match(regex) && firstSrc) {
+                    ruleFailed = true;
+                    firstSrc = false;
+                } else if (value.match(regex) && !firstSrc) {
+                    ruleFailed = false;
+                }
+            }
+
+
+        });
+
+        // Back to normal rules that we don't need to test
+        parser.addListener("endfontface", function(event){
+            fontFaceRule = false;
+
+            if (ruleFailed) {
+                reporter.report("@font-face declaration doesn't follow the fontspring bulletproof syntax.", line, col, rule);
+            }
+        });
+    }
+});

--- a/tests/all-rules.js
+++ b/tests/all-rules.js
@@ -33,11 +33,6 @@
                     Assert.areEqual(0, result.messages.length);
                 },
 
-                "Using @font-face should not result in an error": function(){
-                    var result = CSSLint.verify("@font-face { src: local(foo); }", this.options);
-                    Assert.areEqual(0, result.messages.length);
-                },
-
                 "Using @page should not result in an error": function(){
                     var result = CSSLint.verify("@page { width: 100px; }", this.options);
                     Assert.areEqual(0, result.messages.length);

--- a/tests/rules/bulletproof-font-face.js
+++ b/tests/rules/bulletproof-font-face.js
@@ -1,0 +1,105 @@
+(function(){
+
+    /*global YUITest, CSSLint*/
+    var Assert = YUITest.Assert;
+
+    YUITest.TestRunner.add(new YUITest.TestCase({
+
+        name: "Bulletproof @font-face syntax tests",
+
+        "Using the official bulletproof syntax should pass": function(){
+            var result = CSSLint.verify("@font-face { font-family: 'MyFontFamily';" +
+                                        "src: url('myfont-webfont.eot?') format('embedded-opentype')," +
+                                             "url('myfont-webfont.woff') format('woff')," +
+                                             "url('myfont-webfont.ttf')  format('truetype')," +
+                                             "url('myfont-webfont.svg#svgFontName') format('svg');}",
+                                        { "bulletproof-font-face": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Skipping the hashtag with the svgFontName and having content after .eot? should also pass": function(){
+            var result = CSSLint.verify("@font-face { font-family: 'MyFontFamily';" +
+                                        "src: url('myfont-webfont.eot?#iefix') format('embedded-opentype')," +
+                                             "url('myfont-webfont.woff') format('woff')," +
+                                             "url('myfont-webfont.ttf')  format('truetype')," +
+                                             "url('myfont-webfont.svg') format('svg');}",
+                                        { "bulletproof-font-face": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "The minified version of the code should pass": function(){
+            var result = CSSLint.verify("@font-face{font-family:'MyFontFamily';" +
+                                            "src:url('myfont-webfont.eot?#iefix') format('embedded-opentype')," +
+                                            "url('myfont-webfont.woff') format('woff')," +
+                                            "url('myfont-webfont.ttf') format('truetype')," +
+                                            "url('myfont-webfont.svg#svgFontName') format('svg')}",
+                                        { "bulletproof-font-face": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Skipping one of the font types should pass": function(){
+            var result = CSSLint.verify("@font-face { font-family: 'MyFontFamily';" +
+                                        "src: url('myfont-webfont.eot?') format('embedded-opentype')," +
+                                             "url('myfont-webfont.woff') format('woff')," +
+                                             "url('myfont-webfont.svg#svgFontName') format('svg');}",
+                                        { "bulletproof-font-face": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+
+        "Supplying the fonts in a different order should pass": function(){
+            var result = CSSLint.verify("@font-face { font-family: 'MyFontFamily';" +
+                                        "src: url('myfont-webfont.eot?#iefix') format('embedded-opentype')," +
+                                             "url('myfont-webfont.ttf')  format('truetype')," +
+                                             "url('myfont-webfont.woff') format('woff')," +
+                                             "url('myfont-webfont.svg#svgFontName') format('svg');}",
+                                        { "bulletproof-font-face": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Using mixed double and single quotes should pass": function(){
+            var result = CSSLint.verify("@font-face { font-family: 'MyFontFamily';" +
+                                        "src: url(\"myfont-webfont.eot?#iefix\") format(\"embedded-opentype\")," +
+                                             "url('myfont-webfont.ttf')  format('truetype')," +
+                                             "url(\"myfont-webfont.woff\") format('woff')," +
+                                             "url('myfont-webfont.svg#svgFontName') format('svg');}",
+                                        { "bulletproof-font-face": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Having only one font declaration with the question mark should pass": function(){
+            var result = CSSLint.verify("@font-face{src:url('myfont-webfont.eot?') format('embedded-opentype');}",
+                                        { "bulletproof-font-face": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "When we aren't inside an @font-face declaration the src property should not be checked": function(){
+            var result = CSSLint.verify(".foo .bar{src:url('baz.png');}", { "bulletproof-font-face": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Using the advanced syntax with two src properties should pass": function(){
+            var result = CSSLint.verify("@font-face { font-family: 'MyFontFamily';" +
+                                        "src: url('webfont.eot'); /* IE9 Compat Modes */" +
+                                        "src: url('myfont-webfont.eot?') format('embedded-opentype')," +
+                                             "url('myfont-webfont.woff') format('woff')," +
+                                             "url('myfont-webfont.ttf')  format('truetype')," +
+                                             "url('myfont-webfont.svg#svgFontName') format('svg');}",
+                                        { "bulletproof-font-face": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Leaving off the question mark should fail": function(){
+            var result = CSSLint.verify("@font-face { font-family: 'MyFontFamily';" +
+                                        "src: url('myfont-webfont.eot') format('embedded-opentype')," +
+                                             "url('myfont-webfont.woff') format('woff')," +
+                                             "url('myfont-webfont.ttf')  format('truetype')," +
+                                             "url('myfont-webfont.svg#svgFontName') format('svg');}",
+                                        { "bulletproof-font-face": 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("warning", result.messages[0].type);
+            Assert.areEqual("@font-face declaration doesn't follow the fontspring bulletproof syntax.", result.messages[0].message);
+        }
+
+    }));
+})();


### PR DESCRIPTION
I also removed one of the global tests that is made obsolete by the new rule (basically the test failed if you ever got an error inside of an @font-face declaration).  

This rule is based on this article:

http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

I created it as a project for my company since we use CSSLint internally in our CI environment and we wanted to make sure that people declare fonts correctly. 
