### PR TITLE
Mac fonts check

### DIFF
--- a/src/rules/check-fonts-alternatives.js
+++ b/src/rules/check-fonts-alternatives.js
@@ -32,7 +32,17 @@ CSSLint.addRule({
                 // font-weight related
                 "bold": 6,
                 "bolder": 7,
-                "lighter": 8
+                "lighter": 8,
+                // font-size related
+                "xx-small": 9, 
+                "x-small": 10, 
+                "small": 11, 
+                "medium": 12,
+                "large": 13, 
+                "x-large": 14, 
+                "xx-large": 15,
+                "larger": 16,
+                "smaller": 17
             },
             fontFaceRule = false;
 
@@ -51,6 +61,9 @@ CSSLint.addRule({
             // font-style: normal | italic | oblique | inherit
             // font-variant: normal | small-caps | inherit
             // font-weight: bold|bolder|lighter|normal|100|200|300|400|500|600|700|800|900
+            // font-size: absolute | relative | value | precents | inherit
+            // font-size-absolute: xx-small, x-small, small, medium, large, x-large, xx-large
+            // font-size-relative: larger | smaller
 
             var property = event.property,
                 propertyName = property.text.toLowerCase(),

--- a/tests/rules/check-fonts-alternatives.js
+++ b/tests/rules/check-fonts-alternatives.js
@@ -60,6 +60,20 @@
       Assert.areEqual(mkErrorMessage("MS Serif", "New York"), result.messages[0].message);
     },
 
+    "Font size (absolute) + family form": function(){
+      var result = CSSLint.verify(".c { font: xx-small MS Serif }", testSpec);
+            
+      Assert.areEqual(1, result.messages.length);
+      Assert.areEqual(mkErrorMessage("MS Serif", "New York"), result.messages[0].message);
+    },
+
+    "Font size (relative) + family form": function(){
+      var result = CSSLint.verify(".c { font: larger MS Serif }", testSpec);
+            
+      Assert.areEqual(1, result.messages.length);
+      Assert.areEqual(mkErrorMessage("MS Serif", "New York"), result.messages[0].message);
+    },
+
     "Font - badly formed rule": function(){
       // This is equal to identifier 'Tahoma Tahoma Tahoma'
       var result = CSSLint.verify(".c { font: 14px Tahoma Tahoma Tahoma }", testSpec);


### PR DESCRIPTION
New rule 'check-fonts-alternatives'

This rule is aimed to check, if rule's font families has a specified alternative for Mac OS/iOS based systems.

The case is best illustrated in this article: 
http://www.ampsoft.net/webdesign-l/WindowsMacFonts.html
