### PR TITLE
Fixes #345 - Using absolute paths for the excluded files and the files t...

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -76,7 +76,8 @@ function cli(api){
     function filterFiles(files, options) {
         var excludeList = options["exclude-list"],
             excludeFiles = [],
-            filesToLint = files;
+            filesToLint = files.map(api.getFullPath),
+            fullPath;
 
 
         if (excludeList) {
@@ -91,8 +92,9 @@ function cli(api){
 
             // Remove the excluded files from the list of files to lint
             excludeFiles.forEach(function(value){
-                if (filesToLint.indexOf(value) > -1) {
-                    filesToLint.splice(filesToLint.indexOf(value),1);
+                fullPath = api.getFullPath(value);
+                if (filesToLint.indexOf(fullPath) > -1) {
+                    filesToLint.splice(filesToLint.indexOf(fullPath),1);
                 }
             });
         }


### PR DESCRIPTION
...o lint so the comparison is clean

We now do a little more work in the filterFiles function, but this should be much more robust since we are now comparing absolute paths to absolute paths. 
