### PR TITLE
"Added rule for :visited and :link styles can only differ by color."

### DIFF
--- a/src/rules/visited-styles.js
+++ b/src/rules/visited-styles.js
@@ -1,0 +1,66 @@
+/*
+ * Rule: Visited styles can only differ by color.
+ */
+/*global CSSLint*/
+CSSLint.addRule({
+
+    //rule information
+    id: "visited-styles",
+    name: "Visited Styles",
+    desc: ":visited and :link styles can only differ by color.",
+    browsers: "All",
+
+    //initialization
+    init: function(parser, reporter){
+        var rule = this,
+            lastRule;
+
+        function startRule(event){
+            if (event.selectors){
+                lastRule = {
+                    line: event.line,
+                    col: event.col,
+                    selectors: event.selectors,
+                    propCount: 0,
+                    outline: false,
+                    visitedDiffers: false
+                };
+            } else {
+                lastRule = null;
+            }
+        }
+        
+        function endRule(event){
+            if (lastRule){
+                if (lastRule.visitedDiffers){
+                    if (lastRule.selectors.toString().toLowerCase().indexOf(":visited") != -1) {
+                        reporter.report(":visited and :link styles can only differ by color.", lastRule.line, lastRule.col, rule);
+                    }
+                }
+            }
+        }
+
+        parser.addListener("startrule", startRule);
+        parser.addListener("startfontface", startRule);
+        parser.addListener("startpage", startRule);
+        parser.addListener("startpagemargin", startRule);
+        parser.addListener("startkeyframerule", startRule); 
+
+        parser.addListener("property", function(event){
+            var name = event.property.text.toLowerCase();                
+                
+            if (lastRule){
+                if (name !== "color"){
+                    lastRule.visitedDiffers = true;
+                }            
+            }
+            
+        });
+        
+        parser.addListener("endrule", endRule);
+        parser.addListener("endfontface", endRule);
+        parser.addListener("endpage", endRule);
+        parser.addListener("endpagemargin", endRule);
+        parser.addListener("endkeyframerule", endRule); 
+    }
+});

--- a/tests/rules/visited-styles.js
+++ b/tests/rules/visited-styles.js
@@ -1,0 +1,19 @@
+(function(){
+
+    /*global YUITest, CSSLint*/
+    var Assert = YUITest.Assert;
+
+    YUITest.TestRunner.add(new YUITest.TestCase({
+
+        name: "Visited Styles Errors",
+
+        "Visited links can only differ by color.": function(){
+            var result = CSSLint.verify("a:visited { text-decoration: underline; }", { "visited-styles": 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("warning", result.messages[0].type);
+            Assert.areEqual(":visited and :link styles can only differ by color.", result.messages[0].message);
+        },
+
+    }));
+
+})();


### PR DESCRIPTION
"Added rule for ':visited and :link styles can only differ by color.' See: http://msdn.microsoft.com/en-us/library/ie/hh180764(v=vs.85).aspx and https://developer.mozilla.org/en-US/docs/CSS/Privacy_and_the_:visited_selector for details."
