### PR TITLE
Update CSSLint.js

### DIFF
--- a/src/core/CSSLint.js
+++ b/src/core/CSSLint.js
@@ -182,7 +182,7 @@ var CSSLint = (function(){
         lines = text.replace(/\n\r?/g, "$split$").split('$split$');
 
         if (!ruleset){
-            ruleset = this.getRuleset();
+            ruleset = api.getRuleset();
         }
 
         if (embeddedRuleset.test(text)){


### PR DESCRIPTION
Hi if I call verify without a ruleset and the fallback case **getRuleset** is called i get:

```
node_modules/csslint/lib/csslint-node.js:6564
            ruleset = this.getRuleset();
                           ^
TypeError: Object #<Object> has no method 'getRuleset'
```

changing this to `api.getRuleset()` fixes the problem
