### PR TITLE
Fix #364. In WSH, return empty string for files not found.

### DIFF
--- a/src/cli/wsh.js
+++ b/src/cli/wsh.js
@@ -122,9 +122,14 @@ var wshapi = (function(){
 
         readFile: function(path){
             var forReading = 1;
-            var tf = fso.OpenTextFile(path, forReading);
-            var allText = tf.ReadAll();
-            tf.Close();
+            var allText;
+            try {
+                var tf = fso.OpenTextFile(path, forReading);
+                allText = tf.ReadAll();
+                tf.Close();
+            } catch (ex) {
+                return "";
+            }
             return allText;
         }
     };


### PR DESCRIPTION
The `fso.OpenTextFile` method throws an exception when the file doesn't exist. For those cases, just return an empty string.
