### PR TITLE
Bump minimum Node version to 0.8 and add CI tests environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+  - "0.11"
 before_install:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     }
   ],
   "engines": {
-    "node": ">=0.2.0"
+    "node": ">=0.8.0"
   },
   "directories": {
     "lib": "lib"

--- a/src/cli/node.js
+++ b/src/cli/node.js
@@ -17,16 +17,7 @@ cli({
     },
     
     quit: function(code){
-    
-        //Workaround for https://github.com/joyent/node/issues/1669
-        
-        if ((!process.stdout.flush || !process.stdout.flush()) && (parseFloat(process.versions.node) < 0.5)) {
-            process.once("drain", function () {
-                process.exit(code || 0);
-            });
-        } else {
-            process.exit(code || 0);
-        }
+        process.exit(code || 0);
     },
     
     isDirectory: function(name){


### PR DESCRIPTION
- Removes workaround for node exit not properly flushing on 0.4 and lower
- Add Travis test runs for each of the supported node version

Fixes #378
