### PR TITLE
Add README copy for NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 csslint.pnproj
 build/
 node_modules/
+release/npm/README.md

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -133,6 +133,7 @@ module.exports = function(grunt) {
             release: {
                 files: {
                     '<%= build_dir %>': 'release',
+                    'release/npm/README.md': 'README.md',
                     'release/npm/package.json': 'package.json'
                 }
             }


### PR DESCRIPTION
Ignored for check-in since it would just be a direct copy.
This will render a copy of the README on the npm page https://npmjs.org/package/csslint
