### PR TITLE
Add "rule" attribute to "lintxml" output format

### DIFF
--- a/src/formatters/lint-xml.js
+++ b/src/formatters/lint-xml.js
@@ -39,7 +39,7 @@ CSSLint.addFormatter({
          *  - &amp; is the escape sequence for &
          *  - &lt; is the escape sequence for <
          *  - &gt; is the escape sequence for >
-         * 
+         *
          * @param {String} message to escape
          * @return escaped message as {String}
          */
@@ -51,13 +51,17 @@ CSSLint.addFormatter({
         };
 
         if (messages.length > 0) {
-        
+
             output.push("<file name=\""+filename+"\">");
             CSSLint.Util.forEach(messages, function (message, i) {
                 if (message.rollup) {
                     output.push("<issue severity=\"" + message.type + "\" reason=\"" + escapeSpecialCharacters(message.message) + "\" evidence=\"" + escapeSpecialCharacters(message.evidence) + "\"/>");
                 } else {
-                    output.push("<issue line=\"" + message.line + "\" char=\"" + message.col + "\" severity=\"" + message.type + "\"" +
+                    var rule = '';
+                    if (message.rule && message.rule.id) {
+                      rule = 'rule=\"' + escapeSpecialCharacters(message.rule.id) + '\" ';
+                    }
+                    output.push("<issue " + rule + "line=\"" + message.line + "\" char=\"" + message.col + "\" severity=\"" + message.type + "\"" +
                         " reason=\"" + escapeSpecialCharacters(message.message) + "\" evidence=\"" + escapeSpecialCharacters(message.evidence) + "\"/>");
                 }
             });

--- a/tests/formatters/lint-xml.js
+++ b/tests/formatters/lint-xml.js
@@ -6,7 +6,7 @@
     YUITest.TestRunner.add(new YUITest.TestCase({
 
         name: "Lint XML formatter test",
-        
+
         "File with no problems should say so": function(){
             var result = { messages: [], stats: [] },
                 expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?><lint></lint>";
@@ -38,6 +38,25 @@
                 expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?><lint>" + file + error1 + error2 + "</file></lint>",
                 actual = CSSLint.format(result, "FILE", "lint-xml");
             Assert.areEqual(expected, actual);
+        },
+
+        "Messages should include rule IDs": function() {
+          var result = { messages: [
+            { type: "error", line: 1, col: 1, message: "X", evidence: "Y", rule: { id: "Z" } }
+          ], stats: [] };
+
+          var expected =
+            '<?xml version="1.0" encoding="utf-8"?>' +
+            '<lint>' +
+              '<file name="FILE">' +
+                '<issue rule="Z" line="1" char="1" severity="error" reason="X" evidence="Y"/>' +
+              '</file>' +
+            '</lint>';
+
+          var actual = CSSLint.format(result, "FILE", "lint-xml");
+
+          Assert.areEqual(expected, actual);
         }
+
     }));
 })();


### PR DESCRIPTION
Summary: Currently, there's no way to determine which rule generated a lint
message if you have a parser on top of CSSLint. Provide a `rule` attribute
which has the rule ID.

(The specific motivating use case is that I have a program which runs multiple
linters, manages lint message severity above the linter level, and has more
severity levels than CSSLint itself does, so using flags like `--ignore` would
require special casing and reduce flexibility.)

Test Plan: Added new test coverage and executed unit tests.