### PR TITLE
Add alphabetical order rule

### DIFF
--- a/src/rules/order-alphabetical.js
+++ b/src/rules/order-alphabetical.js
@@ -1,0 +1,45 @@
+/*
+ * Rule: All properties should be in alphabetical order..
+ */
+/*global CSSLint*/
+CSSLint.addRule({
+
+    //rule information
+    id: "order-alphabetical",
+    name: "Alphabetical order",
+    desc: "Assure properties are in alphabetical order",
+    browsers: "All",
+
+    //initialization
+    init: function(parser, reporter){
+        var rule = this,
+            properties;
+
+        var startRule = function () {
+            properties = [];
+        };
+
+        parser.addListener("startrule", startRule);
+        parser.addListener("startfontface", startRule);
+        parser.addListener("startpage", startRule);
+        parser.addListener("startpagemargin", startRule);
+        parser.addListener("startkeyframerule", startRule);
+
+        parser.addListener("property", function(event){
+            var name = event.property.text,
+                lowerCasePrefixLessName = name.toLowerCase().replace(/^-.*?-/, "");
+
+            properties.push(lowerCasePrefixLessName);
+        });
+
+        parser.addListener("endrule", function(event){
+            var currentProperties = properties.join(','),
+                expectedProperties = properties.sort().join(',');
+
+            if (currentProperties !== expectedProperties){
+                reporter.report("Rule doesn't have all its properties in alphabetical ordered.", event.line, event.col, rule);
+            }
+        });
+    }
+
+});

--- a/tests/rules/order-alphabetical.js
+++ b/tests/rules/order-alphabetical.js
@@ -1,0 +1,36 @@
+(function(){
+
+    /*global YUITest, CSSLint*/
+    var Assert = YUITest.Assert;
+
+    YUITest.TestRunner.add(new YUITest.TestCase({
+
+        name: "Alphabetical order Errors",
+
+        "Rules with properties not in alphabetical order should result in a warning": function(){
+            var result = CSSLint.verify("li { z-index: 2; color: red; }", { "order-alphabetical": 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("warning", result.messages[0].type);
+            Assert.areEqual("Rule doesn't have all its properties in alphabetical ordered.", result.messages[0].message);
+        },
+
+        "Rules with prefixed properties not in alphabetical order (without the prefix) should result in a warning": function(){
+            var result = CSSLint.verify("li { -moz-transition: none; -webkit-box-shadow: none; }", { "order-alphabetical": 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("warning", result.messages[0].type);
+            Assert.areEqual("Rule doesn't have all its properties in alphabetical ordered.", result.messages[0].message);
+        },
+
+        "Rules with properties in alphabetical order should not result in a warning": function(){
+            var result = CSSLint.verify("li { box-shadow: none; color: red; transition: none; }", { "order-alphabetical": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Rules with prefixed properties in alphabetical order should not result in a warning": function(){
+            var result = CSSLint.verify("li { -webkit-box-shadow: none; color: red; -moz-transition: none; }", { "order-alphabetical": 1 });
+            Assert.areEqual(0, result.messages.length);
+        }
+
+    }));
+
+})();


### PR DESCRIPTION
This rule verifies that all properties of a single rule are in alphabetical order.

I know order is a serious debate. I don't want to impose it. I just think people who want to enforce order should be able to do so using awesome csslint ;-)
