### PR TITLE
New rule to detect if a sheet has @import over 31 sheets in IE6-9

### DIFF
--- a/src/rules/import-ie-limit.js
+++ b/src/rules/import-ie-limit.js
@@ -1,0 +1,42 @@
+/*
+ * Rule: IE6-9 supports up to 31 stylesheet import.
+ * Reference:
+ * http://blogs.msdn.com/b/ieinternals/archive/2011/05/14/internet-explorer-stylesheet-rule-selector-import-sheet-limit-maximum.aspx
+ */
+
+CSSLint.addRule({
+
+    //rule information
+    id: "import-ie-limit",
+    name: "@import limit on IE6-IE9",
+    desc: "IE6-9 supports up to 31 @import per stylesheet",
+    browsers: "IE6, IE7, IE8, IE9",
+
+    //initialization
+    init: function(parser, reporter){
+        "use strict";
+        var rule = this,
+            MAX_IMPORT_COUNT = 31,
+            count = 0;
+
+        function startPage(){
+            count = 0;        
+        }
+        
+        parser.addListener("startpage", startPage);
+        
+        parser.addListener("import", function(){
+            count++;
+        });
+
+        parser.addListener("endstylesheet", function() {
+            if (count > MAX_IMPORT_COUNT) {
+                reporter.rollupError(
+                    "Too many @import rules (" + count + "). IE6-9 supports up to 31 import per stylesheet.", 
+                    rule
+                );
+            }
+        });
+    }
+
+});

--- a/tests/rules/import-ie-limit.js
+++ b/tests/rules/import-ie-limit.js
@@ -1,0 +1,47 @@
+(function(){
+    "use strict";
+    var Assert = YUITest.Assert,
+        IMPORT_STATEMENT = "@import url('foo.css');",
+        MAX_IMPORT_LIMIT = 31,
+        withinLimitCss = "",
+        exceedLimitCss = "",
+        greatlyExceedLimitCss = "",
+        i;
+
+    // Build CSS strings to be used in tests
+    withinLimitCss = IMPORT_STATEMENT;
+
+    for (i = 0; i < MAX_IMPORT_LIMIT + 1; i++) {
+        exceedLimitCss += IMPORT_STATEMENT;
+    }
+
+    for (i = 0; i < MAX_IMPORT_LIMIT + 100; i++) {
+        greatlyExceedLimitCss += IMPORT_STATEMENT;
+    }
+
+    YUITest.TestRunner.add(new YUITest.TestCase({
+
+        name: "Import IE Limit Rule Error",
+        
+        "Using @import <= 31 times should not result in error": function(){
+
+            var result = CSSLint.verify(withinLimitCss, { "import-ie-limit": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Using @import > 31 times should result in error": function(){
+            var result = CSSLint.verify(exceedLimitCss, { "import-ie-limit": 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("error", result.messages[0].type);
+            Assert.areEqual("Too many @import rules (32). IE6-9 supports up to 31 import per stylesheet.", result.messages[0].message);
+        },
+
+        "Using @import > 31 times repeatedly should result in a single error": function(){
+            var result = CSSLint.verify(greatlyExceedLimitCss, { "import-ie-limit": 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("error", result.messages[0].type);
+            Assert.areEqual("Too many @import rules (131). IE6-9 supports up to 31 import per stylesheet.", result.messages[0].message);
+        }
+    }));
+
+})();


### PR DESCRIPTION
New rule to detect if a sheet has `@import` over 31 sheets in IE6-9.

While `@import` is technically OK in IE6-9, there is a hard limit you can `@import` per sheet.  This is documented on MSDN [1].

This rule should only apply to IE6 to IE9.

A rule page [2] has been created to document this optional rule.  If accepted, this page should be added to Compatibility section in Rules.

=====

[1] http://blogs.msdn.com/b/ieinternals/archive/2011/05/14/internet-explorer-stylesheet-rule-selector-import-sheet-limit-maximum.aspx

[2] https://github.com/dashk/csslint/wiki/Disallow-a-sheet-@import---31-sheets-in-IE6-9