### PR TITLE
Fix checkstyle format

### DIFF
--- a/src/formatters/checkstyle-xml.js
+++ b/src/formatters/checkstyle-xml.js
@@ -42,7 +42,7 @@
          * @return {String} to prepend before all results
          */
         startFormat: function(){
-            return "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle>";
+            return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle>\n";
         },
 
         /**
@@ -60,7 +60,7 @@
          * @return {String} The error message.
          */
         readError: function(filename, message) {
-            return "<file name=\"" + xmlEscape(filename) + "\"><error line=\"0\" column=\"0\" severty=\"error\" message=\"" + xmlEscape(message) + "\"></error></file>";
+            return "\t<file name=\"" + xmlEscape(filename) + "\">\n\t\t<error line=\"0\" column=\"0\" severty=\"error\" message=\"" + xmlEscape(message) + "\"></error>\n\t</file>\n";
         },
 
         /**
@@ -91,15 +91,15 @@
 
 
             if (messages.length > 0) {
-                output.push("<file name=\""+filename+"\">");
+                output.push("\t<file name=\""+filename+"\">\n");
                 CSSLint.Util.forEach(messages, function (message, i) {
                     //ignore rollups for now
                     if (!message.rollup) {
-                      output.push("<error line=\"" + message.line + "\" column=\"" + message.col + "\" severity=\"" + message.type + "\"" +
-                          " message=\"" + xmlEscape(message.message) + "\" source=\"" + generateSource(message.rule) +"\"/>");
+                      output.push("\t\t<error line=\"" + message.line + "\" column=\"" + message.col + "\" severity=\"" + message.type + "\"" +
+                          " message=\"" + xmlEscape(message.message) + "\" source=\"" + generateSource(message.rule) +"\"/>\n");
                     }
                 });
-                output.push("</file>");
+                output.push("\t</file>\n");
             }
 
             return output.join("");

--- a/src/formatters/checkstyle-xml.js
+++ b/src/formatters/checkstyle-xml.js
@@ -82,10 +82,10 @@
              * @return rule source as {String}
              */
             var generateSource = function(rule) {
-                if (!rule || !('name' in rule)) {
+                if (!rule || !('id' in rule)) {
                     return "";
                 }
-                return 'net.csslint.' + rule.name.replace(/\s/g,'');
+                return 'net.csslint.' + rule.id;
             };
 
 

--- a/tests/formatters/checkstyle-xml.js
+++ b/tests/formatters/checkstyle-xml.js
@@ -9,7 +9,7 @@
 
         "File with no problems should say so": function(){
             var result = { messages: [], stats: [] },
-                expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle></checkstyle>";
+                expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle>\n</checkstyle>";
             Assert.areEqual(expected, CSSLint.format(result, "FILE", "checkstyle-xml"));
         },
 
@@ -18,10 +18,10 @@
                      { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: { id: "a-rule", name: "A Rule"} },
                      { type: "error", line: 2, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: { id: "some-other-rule", name: "Some Other Rule"} }
                 ], stats: [] },
-                file = "<file name=\"FILE\">",
-                error1 = "<error line=\"1\" column=\"1\" severity=\"warning\" message=\"BOGUS\" source=\"net.csslint.a-rule\"/>",
-                error2 = "<error line=\"2\" column=\"1\" severity=\"error\" message=\"BOGUS\" source=\"net.csslint.some-other-rule\"/>",
-                expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle>" + file + error1 + error2 + "</file></checkstyle>",
+                file = "\t<file name=\"FILE\">\n",
+                error1 = "\t\t<error line=\"1\" column=\"1\" severity=\"warning\" message=\"BOGUS\" source=\"net.csslint.a-rule\"/>\n",
+                error2 = "\t\t<error line=\"2\" column=\"1\" severity=\"error\" message=\"BOGUS\" source=\"net.csslint.some-other-rule\"/>\n",
+                expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle>\n" + file + error1 + error2 + "\t</file>\n</checkstyle>",
                 actual = CSSLint.format(result, "FILE", "checkstyle-xml");
             Assert.areEqual(expected, actual);
         },
@@ -32,10 +32,10 @@
                      { type: "warning", line: 1, col: 1, message: specialCharsSting, evidence: "ALSO BOGUS", rule: [] },
                      { type: "error", line: 2, col: 1, message: specialCharsSting, evidence: "ALSO BOGUS", rule: [] }
                 ], stats: [] },
-                file = "<file name=\"FILE\">",
-                error1 = "<error line=\"1\" column=\"1\" severity=\"warning\" message=\"sneaky, &quot;sneaky&quot;, &lt;sneaky&gt;, sneak &amp; sneaky\" source=\"\"/>",
-                error2 = "<error line=\"2\" column=\"1\" severity=\"error\" message=\"sneaky, &quot;sneaky&quot;, &lt;sneaky&gt;, sneak &amp; sneaky\" source=\"\"/>",
-                expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle>" + file + error1 + error2 + "</file></checkstyle>",
+                file = "\t<file name=\"FILE\">\n",
+                error1 = "\t\t<error line=\"1\" column=\"1\" severity=\"warning\" message=\"sneaky, &quot;sneaky&quot;, &lt;sneaky&gt;, sneak &amp; sneaky\" source=\"\"/>\n",
+                error2 = "\t\t<error line=\"2\" column=\"1\" severity=\"error\" message=\"sneaky, &quot;sneaky&quot;, &lt;sneaky&gt;, sneak &amp; sneaky\" source=\"\"/>\n",
+                expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle>\n" + file + error1 + error2 + "\t</file>\n</checkstyle>",
                 actual = CSSLint.format(result, "FILE", "checkstyle-xml");
             Assert.areEqual(expected, actual);
         }

--- a/tests/formatters/checkstyle-xml.js
+++ b/tests/formatters/checkstyle-xml.js
@@ -15,12 +15,12 @@
 
         "File with problems should list them": function(){
             var result = { messages: [
-                     { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: { name: "A Rule"} },
-                     { type: "error", line: 2, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: { name: "Some Other Rule"} }
+                     { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: { id: "a-rule", name: "A Rule"} },
+                     { type: "error", line: 2, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: { id: "some-other-rule", name: "Some Other Rule"} }
                 ], stats: [] },
                 file = "<file name=\"FILE\">",
-                error1 = "<error line=\"1\" column=\"1\" severity=\"warning\" message=\"BOGUS\" source=\"net.csslint.ARule\"/>",
-                error2 = "<error line=\"2\" column=\"1\" severity=\"error\" message=\"BOGUS\" source=\"net.csslint.SomeOtherRule\"/>",
+                error1 = "<error line=\"1\" column=\"1\" severity=\"warning\" message=\"BOGUS\" source=\"net.csslint.a-rule\"/>",
+                error2 = "<error line=\"2\" column=\"1\" severity=\"error\" message=\"BOGUS\" source=\"net.csslint.some-other-rule\"/>",
                 expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle>" + file + error1 + error2 + "</file></checkstyle>",
                 actual = CSSLint.format(result, "FILE", "checkstyle-xml");
             Assert.areEqual(expected, actual);


### PR DESCRIPTION
`source` attribute is converted to lowercase in Jenkins, it is difficult to read not equal to `rule.id`.

In addition, the readability of XML as so bad, I want to add a `\n` and `\t`.
