### PR TITLE
Ignore hack properties in display-property-grouping

### DIFF
--- a/src/rules/display-property-grouping.js
+++ b/src/rules/display-property-grouping.js
@@ -101,7 +101,7 @@ CSSLint.addRule({
         parser.addListener("property", function(event){
             var name = event.property.text.toLowerCase();
 
-            if (propertiesToCheck[name]){
+            if (propertiesToCheck[name] && !event.property.hack){
                 properties[name] = { value: event.value.text, line: event.property.line, col: event.property.col };                    
             }
         });

--- a/tests/rules/display-property-grouping.js
+++ b/tests/rules/display-property-grouping.js
@@ -51,6 +51,11 @@
             Assert.areEqual("width can't be used with display: inline.", result.messages[0].message);
         },
 
+        "Ignore hack properties": function(){
+            var result = CSSLint.verify(".foo { width: 100px; *display: inline; }", { "display-property-grouping": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
         "Margin with inline should result in a warning": function(){
             var result = CSSLint.verify(".foo { margin: 100px; display: inline; }", { "display-property-grouping": 1 });
             Assert.areEqual(1, result.messages.length);


### PR DESCRIPTION
I want to exclude hack properties from display-property-grouping.

``` css
.foo {
  width: 100px;
  *display: inline;
}
```
