### PR TITLE
Support JSON for .csslintrc files.

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -292,8 +292,20 @@ function cli(api){
     }
 
     function readConfigFile(options) {
-        var data = api.readFile(api.getFullPath(".csslintrc"));
+        var data = api.readFile(api.getFullPath(".csslintrc")),
+            json;
         if (data) {
+            if (data.charAt(0) === "{") {
+                try {
+                    json = JSON.parse(data);
+                    data = "";
+                    for (var optionName in json) {
+                        if (json.hasOwnProperty(optionName)) {
+                            data += "--" + optionName + "=" + json[optionName].join();
+                        }
+                    }
+                } catch(e) {}
+            }
             options = processArguments(data.split(/[\s\n\r]+/m), options);
         }
 


### PR DESCRIPTION
@stubbornella [requested a PR for this](https://github.com/stubbornella/csslint/issues/359#issuecomment-35819236) 2 days ago. I [provided this change](https://github.com/stubbornella/csslint/issues/359#issuecomment-15096096) 11 months ago, so it may be stale. I honestly haven't tested since then. Hopefully someone else involved in the discussion (@tkellen, @cowboy, @jzaefferer) can check if this still works and how it'd integrate with grunt-contrib-csslint.
