### PR TITLE
Using an ID in a selector should report first ID column

### DIFF
--- a/src/rules/ids.js
+++ b/src/rules/ids.js
@@ -19,6 +19,7 @@ CSSLint.addRule({
                 part,
                 modifier,
                 idCount,
+                firstIdCol = false,
                 i, j, k;
 
             for (i=0; i < selectors.length; i++){
@@ -31,6 +32,9 @@ CSSLint.addRule({
                         for (k=0; k < part.modifiers.length; k++){
                             modifier = part.modifiers[k];
                             if (modifier.type == "id"){
+                                if (firstIdCol === false) {
+                                    firstIdCol = part.col;
+                                }
                                 idCount++;
                             }
                         }
@@ -38,9 +42,9 @@ CSSLint.addRule({
                 }
 
                 if (idCount == 1){
-                    reporter.report("Don't use IDs in selectors.", selector.line, selector.col, rule);
+                    reporter.report("Don't use IDs in selectors.", selector.line, firstIdCol, rule);
                 } else if (idCount > 1){
-                    reporter.report(idCount + " IDs in the selector, really?", selector.line, selector.col, rule);
+                    reporter.report(idCount + " IDs in the selector, really?", selector.line, firstIdCol, rule);
                 }
             }
 

--- a/tests/rules/ids.js
+++ b/tests/rules/ids.js
@@ -12,6 +12,7 @@
             Assert.areEqual(1, result.messages.length);
             Assert.areEqual("warning", result.messages[0].type);
             Assert.areEqual("Don't use IDs in selectors.", result.messages[0].message);
+            Assert.areEqual(1, result.messages[0].col);
         },
 
         "Using multiple IDs should result in one warning": function(){
@@ -19,6 +20,23 @@
             Assert.areEqual(1, result.messages.length);
             Assert.areEqual("warning", result.messages[0].type);
             Assert.areEqual("2 IDs in the selector, really?", result.messages[0].message);
+            Assert.areEqual(1, result.messages[0].col);
+        },
+
+        "Using an ID in a selector should report column at first ID when only one ID": function(){
+            var result = CSSLint.verify("body #foo { float: left;}", { ids: 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("warning", result.messages[0].type);
+            Assert.areEqual("Don't use IDs in selectors.", result.messages[0].message);
+            Assert.areEqual(6, result.messages[0].col);
+        },
+
+        "Using an ID in a selector should report column at first ID when multiple IDs": function(){
+            var result = CSSLint.verify("body .other #foo #bar #baz { float: left;}", { ids: 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("warning", result.messages[0].type);
+            Assert.areEqual("3 IDs in the selector, really?", result.messages[0].message);
+            Assert.areEqual(13, result.messages[0].col);
         }
     }));
 


### PR DESCRIPTION
- Grab the col the first id was found at in a selector from the part
- Report it later instead of selector.col
- Add unit tests for single and multiple ids

The use case for this is that in the [grunt-lesslint](https://github.com/kevinsawicki/grunt-lesslint/) task we are using source maps to show the original less line that causes the error and since it's reporting column 0 the relevent LESS line is not as accurate as it could be.

For reference: kevinsawicki/grunt-lesslint#6
