### PR TITLE
When testing all, probably best to actually test all and not 25

### DIFF
--- a/tests/all-rules.js
+++ b/tests/all-rules.js
@@ -13,9 +13,10 @@
     var Assert = YUITest.Assert,
         suite   = new YUITest.TestSuite("General Tests for all Rules"),
         rules   = CSSLint.getRules(),
-        i, len;
+        len     = rules.length,
+        i;
 
-    for (i=0, len=25; i < len; i++){
+    for (i=0; i < len; i++){
 
         (function(i, rules){
 


### PR DESCRIPTION
I suspect this is an oversight in the test suite. Was originally created for 25 rules, but there are now 35.
