### PR TITLE
Text formatter: fix grammatical error with one problem detected

### DIFF
--- a/src/formatters/text.js
+++ b/src/formatters/text.js
@@ -36,7 +36,14 @@ CSSLint.addFormatter({
             return options.quiet ? "" : "\n\ncsslint: No errors in " + filename + ".";
         }
 
-        output = "\n\ncsslint: There are " + messages.length  +  " problems in " + filename + ".";
+        output = "\n\ncsslint: There ";
+        if (messages.length == 1) {
+            output += "is 1 problem";
+        } else {
+            output += "are " + messages.length  +  " problems";
+        }
+        output += " in " + filename + ".";
+
         var pos = filename.lastIndexOf("/"),
             shortFilename = filename;
 

--- a/tests/formatters/text.js
+++ b/tests/formatters/text.js
@@ -13,6 +13,16 @@
             Assert.areEqual("\n\ncsslint: No errors in path/to/FILE.", actual);
         },
 
+        "File with one problem should use proper grammar": function() {
+            var result = { messages: [
+                     { type: 'warning', line: 1, col: 1, message: 'BOGUS', evidence: 'ALSO BOGUS', rule: [] }
+                ], stats: [] },
+                error1 = "\n1: warning at line 1, col 1\nBOGUS\nALSO BOGUS",
+                expected = "\n\ncsslint: There is 1 problem in path/to/FILE.\n\nFILE" + error1,
+                actual = CSSLint.getFormatter("text").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE"});
+            Assert.areEqual(expected, actual);
+        },
+
         "Should have no output when quiet option is specified and no errors": function() {
             var result = { messages: [], stats: [] },
                 actual = CSSLint.getFormatter("text").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE", quiet: "true"});


### PR DESCRIPTION
The summary was incorrectly pluralized and had the wrong verb form when there
was only one problem detected.
