### PR TITLE
Patch Array.prototype.map polyfil for JScript

### DIFF
--- a/src/cli/wsh.js
+++ b/src/cli/wsh.js
@@ -72,6 +72,39 @@ var wshapi = (function(){
         };
     }
 
+    //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
+    if (!Array.prototype.map)
+    {
+        Array.prototype.map = function(fun /*, thisArg */ ) {
+            "use strict";
+
+            if (this === void 0 || this === null) {
+                throw new TypeError();
+            }
+
+            var t = Object(this);
+            var len = t.length >>> 0;
+            if (typeof fun !== "function") {
+                throw new TypeError();
+            }
+
+            var res = new Array(len);
+            var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+            for (var i = 0; i < len; i++) {
+                // NOTE: Absolute correctness would demand Object.defineProperty
+                //       be used.  But this method is fairly new, and failure is
+                //       possible only if Object.prototype or Array.prototype
+                //       has a property |i| (very unlikely), so use a less-correct
+                //       but more portable alternative.
+                if (i in t) {
+                    res[i] = fun.call(thisArg, t[i], i, t);
+                }
+            }
+
+            return res;
+        };
+    }
+
     function traverseDir(files, path) {
         var filename, folder = fso.GetFolder(path),
             subFlds, fc = new Enumerator(folder.files);


### PR DESCRIPTION
used into [cli/common.js:93](https://github.com/dmi3y/csslint/blob/wsharraymap/src/cli/common.js#L93)

Note: seems like [csslint-wsh.js](https://github.com/CSSLint/csslint/blob/f1ef64d7cee8f174151db42447dedd3c4ece91c2/release/csslint-wsh.js) was broken for a while, and no complaints since that time. Any good reason why don't freeze development for wsh?
