### PR TITLE
Add a rule to detect LTR properties

### DIFF
--- a/src/rules/ltr-properties.js
+++ b/src/rules/ltr-properties.js
@@ -15,7 +15,6 @@ CSSLint.addRule({
         var properties = {
             "border-left": 1,
             "border-right": 1,
-            "border-radius": 1,
             "border-top-right-radius": 1,
             "border-top-left-radius": 1,
             "border-bottom-right-radius": 1,
@@ -25,49 +24,48 @@ CSSLint.addRule({
             "margin-left": 1,
             "margin-right": 1,
             "text-align": 1,
-            clear: 1,
             background: 1,
             "background-position": 1,
             left: 1,
             right: 1
         },
         potentialProperties = {
+            float: {
+                left: 1,
+                right: 1,
+            },
+            clear: {
+                left: 1,
+                right: 1,
+            },
+        },
+        potentialMultipleValueProperties = {
             padding: 1,
             margin: 1,
             border: 1,
-            float: 1,
+            "border-radius": 1,
         };
 
         parser.addListener("property", function(event){
             var rule = this,
                 name    = event.property.toString().toLowerCase(),
-                // value   = event.value.toString(),
+                value   = event.value.toString(),
                 line    = event.line,
                 col     = event.col;
 
+            // These properties always affect RTL.
             if (properties[name]){
                 reporter.report("Using " + name + " could require an equivalent rule for RTL styling.", line, col, rule);
             }
-            else if (potentialProperties[name]){
-                // Check to see if they are actually affecting LTR.
-                switch(name){
-
-                case "padding":
-                    //do something
-                    break;
-
-                case "margin":
-                    //do something
-                    break;
-
-                case "border":
-                    //do something
-                    break;
-
-                case "float":
-                    //do something
-                    break;
-
+            // These properties could affect RTL, if they have four values.
+            else if (potentialMultipleValueProperties[name] && event.value.parts.length === 4){
+                reporter.report("Using " + name + " in this way could require an equivalent rule for RTL styling.", line, col, rule);
+            }
+            // These properties could affect RTL, if they have certain values.
+            else if(potentialProperties[name]) {
+                var property = potentialProperties[name];
+                if(property[value]) {
+                    reporter.report("Using " + name + " in this way could require an equivalent rule for RTL styling.", line, col, rule);
                 }
             }
         });

--- a/tests/rules/ltr-properties.js
+++ b/tests/rules/ltr-properties.js
@@ -6,15 +6,49 @@
 
         name: "LTR property detection",
 
-        "Using padding-right should result in a warning ": function(){
+        "Using padding-right should result in a warning": function(){
             var result = CSSLint.verify(".foo { padding-right: 10px; }", { "ltr-properties": 1 });
             Assert.areEqual(1, result.messages.length);
             Assert.areEqual("warning", result.messages[0].type);
             Assert.areEqual("Using padding-right could require an equivalent rule for RTL styling.", result.messages[0].message);
         },
 
-        "Using font-size should result no warning ": function(){
+        "Using padding: 0 1px 0 2px should result in a warning": function(){
+            var result = CSSLint.verify(".foo { padding: 0 1px 0 2px; }", { "ltr-properties": 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("warning", result.messages[0].type);
+            Assert.areEqual("Using padding in this way could require an equivalent rule for RTL styling.", result.messages[0].message);
+        },
+
+        "Using float: left should result in a warning": function(){
+            var result = CSSLint.verify(".foo { float: left; }", { "ltr-properties": 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("warning", result.messages[0].type);
+            Assert.areEqual("Using float in this way could require an equivalent rule for RTL styling.", result.messages[0].message);
+        },
+
+        "Using font-size should result no warning": function(){
             var result = CSSLint.verify(".foo { font-size: 10px; }", { "ltr-properties": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Using padding: 10px should result no warning": function(){
+            var result = CSSLint.verify(".foo { padding: 0; }", { "ltr-properties": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Using border-radius: 2px should result no warning": function(){
+            var result = CSSLint.verify(".foo { padding: 0; }", { "ltr-properties": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Using margin: 0 1px should result no warning": function(){
+            var result = CSSLint.verify(".foo { margin: 0 1px; }", { "ltr-properties": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Using clear: none should result no warning": function(){
+            var result = CSSLint.verify(".foo { float: none; }", { "ltr-properties": 1 });
             Assert.areEqual(0, result.messages.length);
         },
     }));


### PR DESCRIPTION
Drupal has a requirement to support RTL languages, this is a lot of work to achieve and often slips through our review process. I want to make csslint a formal part of our review process and having a rule that detects LTR specific properties would be a great help.

I've opened the equivalent issue to track this on Drupal.org here:
https://www.drupal.org/node/2313783
