### PR TITLE
Added ignore capability.

### DIFF
--- a/src/core/Reporter.js
+++ b/src/core/Reporter.js
@@ -6,8 +6,10 @@
  * @param {String[]} lines The text lines of the source.
  * @param {Object} ruleset The set of rules to work with, including if
  *      they are errors or warnings.
+ * @param {Object} explicitly allowed lines
+ * @param {[][]} ingore list of line ranges to be ignored
  */
-function Reporter(lines, ruleset, allow) {
+function Reporter(lines, ruleset, allow, ignore) {
     "use strict";
 
     /**
@@ -48,6 +50,16 @@ function Reporter(lines, ruleset, allow) {
     this.allow = allow;
     if(!this.allow) {
         this.allow = {};
+    }
+
+    /**
+     * Linesets not to include in the report.
+     * @property ignore
+     * @type [][]
+     */
+    this.ignore = ignore;
+    if(!this.ignore) {
+        this.ignore = [];
     }
 }
 
@@ -103,6 +115,16 @@ Reporter.prototype = {
 
         // Check if rule violation should be allowed
         if (this.allow.hasOwnProperty(line) && this.allow[line].hasOwnProperty(rule.id)) {
+            return;
+        }
+
+        var ignore = false;
+        CSSLint.Util.forEach(this.ignore, function (range) {
+            if(range[0] <= line && line <= range[1]) {
+                ignore = true;
+            }
+        });
+        if(ignore) {
             return;
         }
 

--- a/tests/core/CSSLint.js
+++ b/tests/core/CSSLint.js
@@ -69,6 +69,35 @@
             Assert.isTrue(report.allow["2"].hasOwnProperty("box-sizing"));
             Assert.isTrue(report.allow.hasOwnProperty("4"));
             Assert.isTrue(report.allow["4"].hasOwnProperty("box-model"));
+        },
+
+        "Full ignore blocks should be captured": function(){
+            var report = CSSLint.verify("/* csslint ignore:start */\n\n/* csslint ignore:end */");
+            Assert.areEqual(1, report.ignore.length);
+            Assert.areEqual(0, report.ignore[0][0]);
+            Assert.areEqual(2, report.ignore[0][1]);
+        },
+
+        "Whitespace should be no problem inside ignore comments": function(){
+            var report = CSSLint.verify("/*     csslint     ignore:start    */\n\n/*    csslint     ignore:end     */,\n/*csslint ignore:start*/\n/*csslint ignore:end*/");
+            Assert.areEqual(2, report.ignore.length);
+            Assert.areEqual(0, report.ignore[0][0]);
+            Assert.areEqual(2, report.ignore[0][1]);
+            Assert.areEqual(3, report.ignore[1][0]);
+            Assert.areEqual(4, report.ignore[1][1]);
+        },
+
+        "Ignore blocks should be autoclosed": function(){
+            var report = CSSLint.verify("/* csslint ignore:start */\n\n");
+            Assert.areEqual(1, report.ignore.length);
+            Assert.areEqual(0, report.ignore[0][0]);
+            Assert.areEqual(3, report.ignore[0][1]);
+        },
+
+        "Restarting ignore should be harmless": function(){
+            var report = CSSLint.verify("/* csslint ignore:start */\n/* csslint ignore:start */\n");
+            Assert.areEqual(1, report.ignore.length);
+            Assert.areEqual(0, report.ignore[0][0]);
         }
 
     }));

--- a/tests/core/Reporter.js
+++ b/tests/core/Reporter.js
@@ -52,6 +52,14 @@
             reporter.report("Bar", 3, 1, { id: "fake-rule2" });
 
             Assert.areEqual(0, reporter.messages.length);
+        },
+
+        "Ignores should step over a report in their range": function(){
+            var reporter = new CSSLint._Reporter([], { "fake-rule": 1}, {}, [[1,3]]);
+            reporter.report("Foo", 2, 1, { id: "fake-rule" });
+            reporter.report("Bar", 5, 1, { id: "fake-rule" });
+
+            Assert.areEqual(1, reporter.messages.length);
         }
 
     }));


### PR DESCRIPTION
Comments /* csslint ignore:start */ and /* csslint ignore:stop */
will exclude the lines in between. Linting is still done, but any
errors are not reported.

This aims to fix CSSLint/csslint#558.

This is still missing tests and docs. As I am on the road for the next couple of days I still wanted to provide what's been done so far. Comments welcome.