### PR TITLE
More lenient config files syntax

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -306,20 +306,28 @@ function cli(api) {
     function readConfigData(config) {
         var data = readConfigFile(config),
             json,
+            optionName,
+            optionValue,
+            args,
             options = {};
         if (data) {
             if (data.charAt(0) === "{") {
                 try {
                     json = JSON.parse(data);
                     data = "";
-                    for (var optionName in json) {
+                    for (optionName in json) {
                         if (json.hasOwnProperty(optionName)) {
-                            data += "--" + optionName + "=" + json[optionName].join();
+                            optionValue = json[optionName];
+                            if (Array.isArray(optionValue)) {
+                                optionValue = optionValue.join(",");
+                            }
+                            data += "--" + optionName + "=" + optionValue;
                         }
                     }
                 } catch (e) {}
             }
-            options = processArguments(data.split(/[\s\n\r]+/m));
+            args = data.replace(/\s+/g,"").split(/(?=--)/);
+            options = processArguments(args);
         }
 
         return options;


### PR DESCRIPTION
Fix the issue of JSON config files not working with more than one option specified (#567).

Also allow JSON config values to be strings rather than arrays, e.g.
```json
{
    "format": "checkstyle-xml",
    "ignore": "important"
}
```
Finally, and perhaps most significantly, traditionally formatted `.csslintrc` files may now have arbitrary whitespace! So this also addresses #359. The following is now perfectly valid:
```
--ignore=
  adjoining-classes,
  box-model,
  compatible-vendor-prefixes,
  duplicate-background-images,
  import,
  important,
  outline-none,
  overqualified-elements,
  text-indent
--warnings=
  gradients,
  font-sizes,
  floats
--errors=
  shorthand,
  universal-selector,
  fallback-colors
--format=checkstyle-xml

```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/csslint/csslint/568)
<!-- Reviewable:end -->
