### PR TITLE
New rule to detect deep selector counts

### DIFF
--- a/src/rules/order-alphabetical.js
+++ b/src/rules/order-alphabetical.js
@@ -14,11 +14,8 @@ CSSLint.addRule({
     init: function(parser, reporter){
         "use strict";
         var rule = this,
-            properties;
-
-        var startRule = function () {
-            properties = [];
-        };
+            properties = [],
+            startRule = function() {};
 
         var endRule = function(event){
             var currentProperties = properties.join(","),

--- a/src/rules/order-alphabetical.js
+++ b/src/rules/order-alphabetical.js
@@ -14,8 +14,11 @@ CSSLint.addRule({
     init: function(parser, reporter){
         "use strict";
         var rule = this,
-            properties = [],
-            startRule = function() {};
+            properties;
+
+        var startRule = function () {
+            properties = [];
+        };
 
         var endRule = function(event){
             var currentProperties = properties.join(","),

--- a/src/rules/selector-depth.js
+++ b/src/rules/selector-depth.js
@@ -1,0 +1,47 @@
+/*
+ * Rule: Warns against using too many selectors.
+ *
+ */
+
+CSSLint.addRule({
+
+    //rule information
+    id: "selector-depth",
+    name: "Warns against using too many selectors",
+    desc: "Will warn the selectors used are greater than 5 levels deep",
+    browsers: "All",
+
+    //initialization
+    init: function(parser, reporter) {
+        "use strict";
+        var rule = this,
+            limit = 5;
+
+        parser.addListener("startrule", function(event) {
+            var depth = 0,
+                selectors = event.selectors,
+                selectorCount = selectors.length,
+                selector,
+                partsCount,
+                part,
+                i, j;
+
+            for (i = 0; i < selectorCount; i++) {
+                selector = selectors[i];
+                partsCount = selector.parts.length;
+
+                for (j = 0; j < partsCount; j++) {
+                    part = selector.parts[j];
+
+                    if (part.type === parser.SELECTOR_PART_TYPE){
+                        depth++;
+                    }
+                }
+
+                if (depth >= limit) {
+                    reporter.report("You have " + depth + " selectors, try keeping the number under " + limit + ".", part.line, part.col, rule);
+                }
+            }
+        });
+    }
+});

--- a/tests/rules/selector-depth.js
+++ b/tests/rules/selector-depth.js
@@ -1,0 +1,23 @@
+(function(){
+    "use strict";
+    var Assert = YUITest.Assert;
+
+    YUITest.TestRunner.add(new YUITest.TestCase({
+
+        name: "Selector Depth Errors",
+
+        "Using 4 or less selectors should not result in a warning": function() {
+            var result = CSSLint.verify("foo + #bar .baz > a.foo { display: block; }", { "selector-depth": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
+        "Using 5 or more selectors should result in a warning": function() {
+            var result = CSSLint.verify(".foo bar #baz [foo] .bar { display: none; }", { "selector-depth": 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("warning", result.messages[0].type);
+            Assert.areEqual("You have 5 selectors, try keeping the number under 5.", result.messages[0].message);
+        }
+
+    }));
+
+})();


### PR DESCRIPTION
AS CSSLint is commonly used as a base for LESS/SASS linting tools, warning against having a lot of selectors becomes useful as it's easy to overqualify rules when nesting is available.

This also patches the order-alphabetical rule, which is breaking tests in master.
