### PR TITLE
Update reporter message to make it more useful

### DIFF
--- a/src/rules/adjoining-classes.js
+++ b/src/rules/adjoining-classes.js
@@ -34,8 +34,8 @@ CSSLint.addRule({
                             if (modifier.type === "class") {
                                 classCount++;
                             }
-                            if (classCount > 1) {
-                                reporter.report("Don't use adjoining classes.", part.line, part.col, rule);
+                            if (classCount > 1){
+                                reporter.report("Adjoining classes: "+selectors[i].text, part.line, part.col, rule);
                             }
                         }
                     }

--- a/tests/rules/adjoining-classes.js
+++ b/tests/rules/adjoining-classes.js
@@ -10,14 +10,14 @@
             var result = CSSLint.verify(".foo.bar { }", { "adjoining-classes": 1 });
             Assert.areEqual(1, result.messages.length);
             Assert.areEqual("warning", result.messages[0].type);
-            Assert.areEqual("Don't use adjoining classes.", result.messages[0].message);
+            Assert.areEqual("Adjoining classes: .foo.bar", result.messages[0].message);
         },
 
         "Adjoining classes should result in an error": function() {
             var result = CSSLint.verify(".foo.bar { }", { "adjoining-classes": 2 });
             Assert.areEqual(1, result.messages.length);
             Assert.areEqual("error", result.messages[0].type);
-            Assert.areEqual("Don't use adjoining classes.", result.messages[0].message);
+            Assert.areEqual("Adjoining classes: .foo.bar", result.messages[0].message);
         },
 
         "Descendant selector with classes should not result in a warning": function() {


### PR DESCRIPTION
The reported message was 
```
[L101:C3] Don't use adjoining classes. Don't use adjoining classes. (adjoining-classes)
```

This is not really useful and why have the same text twice. My update is
```
[L101:C3] Adjoining classes: .your-class.your-second-class Don't use adjoining classes. (adjoining-classes)
```