### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
   "bugs": {
     "url": "https://github.com/CSSLint/csslint/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/CSSLint/csslint/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "main": "./lib/csslint-node.js",
   "bin": {
     "csslint": "./cli.js"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/