### PR TITLE
optional space between /* and csslint in embedded ruleset; fixes #549

### DIFF
--- a/src/core/CSSLint.js
+++ b/src/core/CSSLint.js
@@ -13,7 +13,7 @@ var CSSLint = (function(){
 
     var rules           = [],
         formatters      = [],
-        embeddedRuleset = /\/\*csslint([^\*]*)\*\//,
+        embeddedRuleset = /\/\*\s?csslint([^\*]*)\*\//,
         api             = new parserlib.util.EventTarget();
 
     api.version = "@VERSION@";

--- a/src/core/CSSLint.js
+++ b/src/core/CSSLint.js
@@ -13,7 +13,7 @@ var CSSLint = (function(){
 
     var rules           = [],
         formatters      = [],
-        embeddedRuleset = /\/\*\s?csslint([^\*]*)\*\//,
+        embeddedRuleset = /\/\*\s*csslint([^\*]*)\*\//,
         api             = new parserlib.util.EventTarget();
 
     api.version = "@VERSION@";

--- a/tests/core/CSSLint.js
+++ b/tests/core/CSSLint.js
@@ -37,6 +37,17 @@
             Assert.areEqual(undefined, ruleset["adjoining-classes"]);
             Assert.areEqual(1, ruleset["text-indent"]);
             Assert.areEqual(1, ruleset["box-sizing"]);
+        },
+
+        "Embedded rulesets should accept whitespace between /* and 'csslint'": function () {
+            var result = CSSLint.verify("/*     csslint bogus, adjoining-classes:true, box-sizing:false */\n.foo.bar{}", {
+                "text-indent": 1,
+                "box-sizing": 1
+            });
+
+            Assert.areEqual(2, result.ruleset["adjoining-classes"]);
+            Assert.areEqual(1, result.ruleset["text-indent"]);
+            Assert.areEqual(0, result.ruleset["box-sizing"]);
         }
 
     }));


### PR DESCRIPTION
Pretty straightforward; most other linters I've worked with allow for a space between `/*` and the linter name for embedded ruleset comments.  I think csslint should support the same as a very small enhancement.  Thanks for your consideration!