### PR TITLE
Add a JSON formatter

### DIFF
--- a/src/formatters/json.js
+++ b/src/formatters/json.js
@@ -1,3 +1,5 @@
+/* globals JSON: true */
+
 CSSLint.addFormatter({
     //format information
     id: "json",
@@ -24,10 +26,11 @@ CSSLint.addFormatter({
     /**
      * Given CSS Lint results for a file, return output for this format.
      * @param results {Object} with error and warning messages
+     * @param filename {String} relative file path (Unused)
      * @return {String} output for results
      */
     formatResults: function(results, filename, options) {
         "use strict";
-        return options.quiet ? "" : JSON.stringify(results);
+        return options.quiet && results.messages.length < 1 ? "" : JSON.stringify(results);
     }
 });

--- a/src/formatters/json.js
+++ b/src/formatters/json.js
@@ -11,6 +11,7 @@ CSSLint.addFormatter({
      */
     startFormat: function() {
         "use strict";
+        this.json = [];
         return "";
     },
 
@@ -20,7 +21,15 @@ CSSLint.addFormatter({
      */
     endFormat: function() {
         "use strict";
-        return "";
+        var ret = "";
+        if (this.json.length > 0) {
+            if (this.json.length === 1) {
+                ret = JSON.stringify(this.json[0]);
+            } else {
+                ret = JSON.stringify(this.json);
+            }
+        }
+        return ret;
     },
 
     /**
@@ -31,6 +40,13 @@ CSSLint.addFormatter({
      */
     formatResults: function(results, filename, options) {
         "use strict";
-        return options.quiet && results.messages.length < 1 ? "" : JSON.stringify(results);
+        if (results.messages.length > 0 || !options.quiet) {
+            this.json.push({
+                filename: filename,
+                messages: results.messages,
+                stats: results.stats
+            });
+        }
+        return "";
     }
 });

--- a/src/formatters/json.js
+++ b/src/formatters/json.js
@@ -1,0 +1,33 @@
+CSSLint.addFormatter({
+    //format information
+    id: "json",
+    name: "JSON",
+
+    /**
+     * Return content to be printed before all file results.
+     * @return {String} to prepend before all results
+     */
+    startFormat: function() {
+        "use strict";
+        return "";
+    },
+
+    /**
+     * Return content to be printed after all file results.
+     * @return {String} to append after all results
+     */
+    endFormat: function() {
+        "use strict";
+        return "";
+    },
+
+    /**
+     * Given CSS Lint results for a file, return output for this format.
+     * @param results {Object} with error and warning messages
+     * @return {String} output for results
+     */
+    formatResults: function(results, filename, options) {
+        "use strict";
+        return options.quiet ? "" : JSON.stringify(results);
+    }
+});

--- a/tests/formatters/json.js
+++ b/tests/formatters/json.js
@@ -1,0 +1,33 @@
+(function(){
+    "use strict";
+    var Assert = YUITest.Assert;
+
+    YUITest.TestRunner.add(new YUITest.TestCase({
+
+        name: "JSON formatter",
+
+        "File with no problems should say so": function() {
+            var result = { messages: [], stats: [] },
+                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE"});
+            Assert.areEqual("{\"messages\":[],\"stats\":[]}", actual);
+        },
+
+        "Should have no output when quiet option is specified and no errors": function() {
+            var result = { messages: [], stats: [] },
+                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE", quiet: "true"});
+            Assert.areEqual("", actual);
+        },
+
+        "File with problems should list them": function() {
+            var result = { messages: [
+                { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] },
+                { type: "error", line: 2, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] }
+            ], stats: [] },
+                expected = "{\"messages\":[{\"type\":\"warning\",\"line\":1,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]},{\"type\":\"error\",\"line\":2,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]}],\"stats\":[]}",
+                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE"});
+            Assert.areEqual(expected, actual);
+        }
+
+    }));
+
+})();

--- a/tests/formatters/json.js
+++ b/tests/formatters/json.js
@@ -18,6 +18,16 @@
             Assert.areEqual("", actual);
         },
 
+        "Should have output when quiet option is specified and there are errors": function() {
+            var result = { messages: [
+                { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] },
+                { type: "error", line: 2, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] }
+            ], stats: [] },
+                expected = "{\"messages\":[{\"type\":\"warning\",\"line\":1,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]},{\"type\":\"error\",\"line\":2,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]}],\"stats\":[]}",
+                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE", quiet: "true"});
+            Assert.areEqual(expected, actual);
+        },
+
         "File with problems should list them": function() {
             var result = { messages: [
                 { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] },

--- a/tests/formatters/json.js
+++ b/tests/formatters/json.js
@@ -7,24 +7,35 @@
         name: "JSON formatter",
 
         "File with no problems should say so": function() {
-            var result = { messages: [], stats: [] },
-                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE"});
-            Assert.areEqual("{\"messages\":[],\"stats\":[]}", actual);
+            var result = { messages: [], stats: [] };
+            var expected = "{\"filename\":\"path/to/FILE\",\"messages\":[],\"stats\":[]}";
+            var formatter = CSSLint.getFormatter("json");
+            var actual = formatter.startFormat() +
+                formatter.formatResults(result, "path/to/FILE",
+                    {fullPath: "/absolute/path/to/FILE"}) +
+                formatter.endFormat();
+            Assert.areEqual(expected, actual);
         },
 
         "Should have no output when quiet option is specified and no errors": function() {
-            var result = { messages: [], stats: [] },
-                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE", quiet: "true"});
+            var result = { messages: [], stats: [] };
+            var formatter = CSSLint.getFormatter("json");
+            var actual = formatter.startFormat() +
+                formatter.formatResults(result, "path/to/FILE",
+                    {fullPath: "/absolute/path/to/FILE", quiet: "true"}) +
+                formatter.endFormat();
             Assert.areEqual("", actual);
         },
 
         "Should have output when quiet option is specified and there are errors": function() {
             var result = { messages: [
-                { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] },
-                { type: "error", line: 2, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] }
-            ], stats: [] },
-                expected = "{\"messages\":[{\"type\":\"warning\",\"line\":1,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]},{\"type\":\"error\",\"line\":2,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]}],\"stats\":[]}",
-                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE", quiet: "true"});
+                { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] }], stats: [] };
+            var expected = "{\"filename\":\"path/to/FILE\",\"messages\":[{\"type\":\"warning\",\"line\":1,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]}],\"stats\":[]}";
+            var formatter = CSSLint.getFormatter("json");
+            var actual = formatter.startFormat() +
+                formatter.formatResults(result, "path/to/FILE",
+                    {fullPath: "/absolute/path/to/FILE", quiet: "true"}) +
+                formatter.endFormat();
             Assert.areEqual(expected, actual);
         },
 
@@ -32,9 +43,27 @@
             var result = { messages: [
                 { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] },
                 { type: "error", line: 2, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] }
-            ], stats: [] },
-                expected = "{\"messages\":[{\"type\":\"warning\",\"line\":1,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]},{\"type\":\"error\",\"line\":2,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]}],\"stats\":[]}",
-                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE"});
+            ], stats: [] };
+            var  expected = "{\"filename\":\"path/to/FILE\",\"messages\":[{\"type\":\"warning\",\"line\":1,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]},{\"type\":\"error\",\"line\":2,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]}],\"stats\":[]}";
+            var formatter = CSSLint.getFormatter("json");
+            var actual = formatter.startFormat() +
+                formatter.formatResults(result, "path/to/FILE",
+                    {fullPath: "/absolute/path/to/FILE"}) +
+                formatter.endFormat();
+            Assert.areEqual(expected, actual);
+        },
+
+        "Multiple files are handled properly": function () {
+            var result = { messages: [
+                { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] }], stats: [] };
+            var expected = "[{\"filename\":\"path/to/FILE\",\"messages\":[{\"type\":\"warning\",\"line\":1,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]}],\"stats\":[]},{\"filename\":\"path/to/FILE\",\"messages\":[{\"type\":\"warning\",\"line\":1,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]}],\"stats\":[]}]";
+            var formatter = CSSLint.getFormatter("json");
+            var actual = formatter.startFormat() +
+                formatter.formatResults(result, "path/to/FILE",
+                    {fullPath: "/absolute/path/to/FILE"}) +
+                formatter.formatResults(result, "path/to/FILE",
+                    {fullPath: "/absolute/path/to/FILE"}) +
+                formatter.endFormat();
             Assert.areEqual(expected, actual);
         }
 


### PR DESCRIPTION
Add a JSON formatter option, allowing easier use in tools that have native modes of parsing this output.