### PR TITLE
Dynamic classes are not overqualified

### DIFF
--- a/src/rules/overqualified-elements.js
+++ b/src/rules/overqualified-elements.js
@@ -33,7 +33,7 @@ CSSLint.addRule({
                             modifier = part.modifiers[k];
                             if (part.elementName && modifier.type === "id"){
                                 reporter.report("Element (" + part + ") is overqualified, just use " + modifier + " without element name.", part.line, part.col, rule);
-                            } else if (modifier.type === "class"){
+                            } else if (modifier.type === "class" && modifier.text.indexOf(".ng-") === -1) {
 
                                 if (!classes[modifier]){
                                     classes[modifier] = [];

--- a/tests/rules/overqualified-elements.js
+++ b/tests/rules/overqualified-elements.js
@@ -18,6 +18,11 @@
             Assert.areEqual(0, result.messages.length);
         },
 
+        "Using a dynamic class with an element should not result in a warning": function(){
+            var result = CSSLint.verify("a.ng-hide { float: left;}", { "overqualified-elements": 1 });
+            Assert.areEqual(0, result.messages.length);
+        },
+
         "Using a class with an element should result in one warning": function(){
             var result = CSSLint.verify("li.foo { float: left;}", { "overqualified-elements": 1 });
             Assert.areEqual(1, result.messages.length);


### PR DESCRIPTION
Frameworks like angular-js create dynamic classes like ng-hide that might require styling other than the styles from the frameworks stylesheet. Since the framework style sheet is not linted the combination ".ng-hide {...} a.ng-hide {...}" is not excluded from a warning.

This request will prevent unsound recommendations like: "WARNING: Element (li.ng-leave) is overqualified, just use .ng-leave without element name...".
