### PR TITLE
The same overqualification can occur more than once

### DIFF
--- a/src/rules/overqualified-elements.js
+++ b/src/rules/overqualified-elements.js
@@ -48,13 +48,20 @@ CSSLint.addRule({
 
         parser.addListener("endstylesheet", function(){
 
-            var prop;
+            var equalParts,
+                lines,
+                prop;
             for (prop in classes){
                 if (classes.hasOwnProperty(prop)){
-
-                    //one use means that this is overqualified
-                    if (classes[prop].length === 1 && classes[prop][0].part.elementName){
-                        reporter.report("Element (" + classes[prop][0].part + ") is overqualified, just use " + classes[prop][0].modifier + " without element name.", classes[prop][0].part.line, classes[prop][0].part.col, rule);
+					equalParts = true;
+					lines = [];
+					for (var i = 0; i < classes[prop].length; i++) {
+						lines.push(classes[prop][i].part.line);
+						equalParts = equalParts && (classes[prop][i].part.text === classes[prop][0].part.text);
+					}
+                    //one use or multiple equal uses means that this is overqualified
+                    if (classes[prop][0].part.elementName && equalParts) {
+                        reporter.report("Element (" + classes[prop][0].part + ") is overqualified, just use " + classes[prop][0].modifier + " without element name, line " + lines.join(', ') + ".", classes[prop][0].part.line, classes[prop][0].part.col, rule);
                     }
                 }
             }

--- a/tests/rules/overqualified-elements.js
+++ b/tests/rules/overqualified-elements.js
@@ -33,6 +33,13 @@
         "Using a class with an element and without should not result in a warning": function(){
             var result = CSSLint.verify("li.foo { float: left;} .foo { float: right; }", { "overqualified-elements": 1 });
             Assert.areEqual(0, result.messages.length);
+        },
+
+        "Using a class with the same element more than once should result in a warning": function(){
+            var result = CSSLint.verify("li.foo { float: left;} li.foo { float: right; }", { "overqualified-elements": 1 });
+            Assert.areEqual(1, result.messages.length);
+            Assert.areEqual("warning", result.messages[0].type);
+            Assert.areEqual("Element (li.foo) is overqualified, just use .foo without element name (found 2x).", result.messages[0].message);
         }
 
     }));


### PR DESCRIPTION
"div.class-name {...} div.class-name {...}" will not get a warning, probably to prevent a warning for "div.class-name {...} span.class-name {...}" This code warns for multiple occurances of a classname with the same modifier.