### PR TITLE
Fix #666 : Make core (dist/csslint.js) compatible with CodeMirror in …

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,10 +65,10 @@ module.exports = function(grunt) {
             core: {
                 options: {
                     banner: "<%= banner %>\n" +
+                            "var CSSLint = (function(){\n" +
                             // Hack for using the node version of parserlib and clone
-                            "var module = module || {},\n" +
-                            "    exports = exports || {};\n\n" +
-                            "var CSSLint = (function(){\n",
+                            "  var module = module || {},\n" +
+                            "      exports = exports || {};\n\n",
                     footer: "\nreturn CSSLint;\n})();"
                 },
                 src: [


### PR DESCRIPTION
@XhmikosR Please see Fix #666 : Make core (dist/csslint.js) compatible with CodeMirror in browser, 

- in general, any environment that supports CommonJS module,
  which expect proper module, exports global