### PR TITLE
685 Ignore doesn't ignore

### DIFF
--- a/tests/core/CSSLint.js
+++ b/tests/core/CSSLint.js
@@ -98,6 +98,11 @@
             var report = CSSLint.verify("/* csslint ignore:start */\n/* csslint ignore:start */\n");
             Assert.areEqual(1, report.ignore.length);
             Assert.areEqual(0, report.ignore[0][0]);
+        },
+
+        "Ignore should remove warning messages": function() {
+            var report = CSSLint.verify("/* csslint ignore:start */\nh1 {}\nh1 {}/* csslint ignore:end */\n");
+            Assert.areEqual(0, report.messages.length);
         }
 
     }));


### PR DESCRIPTION
For csslint this is a *warning* of multiple styles overlapping:
```
h1 {}
h1 {}
```
Currently warnings are not silenced in stdout even when surrounded by a `csslint ignore` block.