### PR TITLE
Pass options through to rule verification

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -140,7 +140,7 @@ function cli(api) {
     function processFile(relativeFilePath, options) {
         var input = api.readFile(relativeFilePath),
             ruleset = filterRules(options),
-            result = CSSLint.verify(input, gatherRules(options, ruleset)),
+            result = CSSLint.verify(input, gatherRules(options, ruleset), options),
             formatter = CSSLint.getFormatter(options.format || "text"),
             messages = result.messages || [],
             output,

--- a/src/core/CSSLint.js
+++ b/src/core/CSSLint.js
@@ -169,10 +169,11 @@ var CSSLint = (function() {
      * @param {Object} ruleset (Optional) List of rules to apply. If null, then
      *      all rules are used. If a rule has a value of 1 then it's a warning,
      *      a value of 2 means it's an error.
+     * @param {Object} options (Optional) options for processing
      * @return {Object} Results of the verification.
      * @method verify
      */
-    api.verify = function(text, ruleset) {
+    api.verify = function(text, ruleset, options) {
 
         var i = 0,
             reporter,
@@ -245,7 +246,7 @@ var CSSLint = (function() {
         for (i in ruleset) {
             if (ruleset.hasOwnProperty(i) && ruleset[i]) {
                 if (rules[i]) {
-                    rules[i].init(parser, reporter);
+                    rules[i].init(parser, reporter, options);
                 }
             }
         }

--- a/src/core/Reporter.js
+++ b/src/core/Reporter.js
@@ -133,7 +133,7 @@ Reporter.prototype = {
             line    : line,
             col     : col,
             message : message,
-            evidence: this.lines[line-1],
+            evidence: this.lines[line-1] || "",
             rule    : rule
         });
     },


### PR DESCRIPTION
- Enable the verify API to accept an options object
- Pass the options object through to the verify API from the command line
- Fix a defect in the reporter than sets the 'evidence' property to undefined instead of empty string